### PR TITLE
Add A3 handover rule and simple mode tests

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/handover/a3_rule.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/handover/a3_rule.py
@@ -1,0 +1,22 @@
+"""Event A3 handover rule with hysteresis and time-to-trigger."""
+from datetime import datetime, timedelta
+
+class A3EventRule:
+    """Implements 3GPP Event A3 hysteresis/time-to-trigger logic."""
+    def __init__(self, hysteresis_db: float = 2.0, ttt_seconds: float = 0.0):
+        self.hysteresis_db = hysteresis_db
+        self.ttt = timedelta(seconds=ttt_seconds)
+        self._start: datetime | None = None
+
+    def check(self, rsrp_serving: float, rsrp_target: float, now: datetime) -> bool:
+        """Return True if the A3 condition has been met for the duration."""
+        diff = rsrp_target - rsrp_serving
+        if diff > self.hysteresis_db:
+            if self._start is None:
+                self._start = now
+            elif now - self._start >= self.ttt:
+                self._start = None
+                return True
+        else:
+            self._start = None
+        return False

--- a/5g-network-optimization/services/nef-emulator/tests/test_a3_rule.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_a3_rule.py
@@ -1,0 +1,72 @@
+# tests/test_a3_rule.py
+
+import sys
+import os
+from datetime import datetime, timedelta
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
+import pytest
+from backend.app.app.network.state_manager import NetworkStateManager
+
+class DummyAntenna:
+    def __init__(self, rsrp):
+        self._rsrp = rsrp
+    def rsrp_dbm(self, pos):
+        return self._rsrp
+
+def patch_time(monkeypatch, times):
+    import backend.app.app.network.state_manager as sm
+    it = iter(times)
+    class FakeDT(datetime):
+        @classmethod
+        def utcnow(cls):
+            return next(it)
+    monkeypatch.setattr(sm, 'datetime', FakeDT)
+
+
+def test_a3_handover_trigger(monkeypatch):
+    base = datetime(2025,1,1)
+    times = [base, base + timedelta(seconds=0.5),
+             base + timedelta(seconds=1.1), base + timedelta(seconds=1.1)]
+    patch_time(monkeypatch, times)
+
+    n = NetworkStateManager(simple_mode=True, a3_hysteresis_db=3.0, a3_ttt_s=1.0)
+    n.antenna_list = {'A': DummyAntenna(-80), 'B': DummyAntenna(-76)}
+    n.ue_states = {'u1': {'position': (0,0,0), 'connected_to': 'A'}}
+
+    # first call starts timer
+    assert n.apply_handover_decision('u1', 'B') is None
+    # before ttt expiry
+    assert n.apply_handover_decision('u1', 'B') is None
+    # after ttt -> handover occurs
+    ev = n.apply_handover_decision('u1', 'B')
+    assert ev and ev['from']=='A' and ev['to']=='B'
+
+
+def test_a3_timer_reset(monkeypatch):
+    base = datetime(2025,1,1)
+    times = [base, base + timedelta(seconds=0.5),
+             base + timedelta(seconds=1.0),
+             base + timedelta(seconds=2.2),
+             base + timedelta(seconds=2.2)]
+    patch_time(monkeypatch, times)
+
+    n = NetworkStateManager(simple_mode=True, a3_hysteresis_db=3.0, a3_ttt_s=1.0)
+    antB = DummyAntenna(-76)
+    n.antenna_list = {'A': DummyAntenna(-80), 'B': antB}
+    n.ue_states = {'u1': {'position': (0,0,0), 'connected_to': 'A'}}
+
+    # start timer with diff=4
+    assert n.apply_handover_decision('u1', 'B') is None
+    # drop below hysteresis -> timer reset
+    antB._rsrp = -82
+    assert n.apply_handover_decision('u1', 'B') is None
+    # difference > H again -> start new timer
+    antB._rsrp = -76
+    assert n.apply_handover_decision('u1', 'B') is None
+    # after ttt from restart -> should handover
+    ev = n.apply_handover_decision('u1', 'B')
+    assert ev and n.ue_states['u1']['connected_to']=='B'


### PR DESCRIPTION
## Summary
- implement Event A3 rule with hysteresis and time-to-trigger
- support simple-mode handovers using the rule in `NetworkStateManager`
- add tests for the A3 rule

## Testing
- `pytest tests/test_a3_rule.py tests/test_state_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68567babf8d08333a16a288ef8b42dcf

## Summary by Sourcery

Implement 3GPP A3 event-based handover rule and integrate it into NetworkStateManager's simple-mode, with corresponding tests

New Features:
- Add A3EventRule class with hysteresis and time-to-trigger logic for handover events
- Enable simple-mode in NetworkStateManager to apply the A3 rule for decision-making

Enhancements:
- Extend NetworkStateManager constructor to accept simple_mode, A3 hysteresis, and time-to-trigger parameters
- Update apply_handover_decision to conditionally invoke rule-based logic in simple_mode

Tests:
- Add unit tests for A3EventRule timing, hysteresis behavior, and simple-mode handover execution