### PR TITLE
Add ML-enabled handover engine

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/handover/engine.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/handover/engine.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Optional
+
+from app.network.state_manager import NetworkStateManager
+from .a3_rule import A3EventRule
+
+try:
+    from app.models.antenna_selector import AntennaSelector
+except Exception:  # pragma: no cover - optional dependency
+    AntennaSelector = None  # type: ignore
+
+
+class HandoverEngine:
+    """Decide and apply handovers using rule-based or ML approaches."""
+
+    def __init__(
+        self,
+        state_mgr: NetworkStateManager,
+        use_ml: Optional[bool] = None,
+        ml_model_path: Optional[str] = None,
+        min_antennas_ml: int = 4,
+        a3_hysteresis_db: float = 2.0,
+        a3_ttt_s: float = 0.0,
+    ) -> None:
+        self.state_mgr = state_mgr
+
+        if use_ml is None:
+            env = os.getenv("ML_HANDOVER_ENABLED")
+            if env is not None:
+                use_ml = env.lower() in {"1", "true", "yes"}
+            else:
+                use_ml = len(state_mgr.antenna_list) >= min_antennas_ml
+        self.use_ml = bool(use_ml)
+
+        if self.use_ml:
+            if AntennaSelector is None:
+                raise RuntimeError("AntennaSelector not available")
+            self.selector = AntennaSelector(model_path=ml_model_path)
+        else:
+            self.rule = A3EventRule(hysteresis_db=a3_hysteresis_db, ttt_seconds=a3_ttt_s)
+
+    # ------------------------------------------------------------------
+    def _select_ml(self, ue_id: str) -> Optional[str]:
+        fv = self.state_mgr.get_feature_vector(ue_id)
+        rf_metrics = {
+            aid: {
+                "rsrp": fv["neighbor_rsrs"][aid],
+                "sinr": fv["neighbor_sinrs"][aid],
+            }
+            for aid in fv["neighbor_rsrs"]
+        }
+        ue_data = {
+            "ue_id": ue_id,
+            "latitude": fv["latitude"],
+            "longitude": fv["longitude"],
+            "speed": fv.get("speed", 0.0),
+            "direction": (0, 0, 0),
+            "connected_to": fv["connected_to"],
+            "rf_metrics": rf_metrics,
+        }
+        feats = self.selector.extract_features(ue_data)
+        pred = self.selector.predict(feats)
+        return pred.get("antenna_id")
+
+    def _select_rule(self, ue_id: str) -> Optional[str]:
+        fv = self.state_mgr.get_feature_vector(ue_id)
+        current = fv["connected_to"]
+        now = datetime.utcnow()
+        for aid, rsrp in fv["neighbor_rsrs"].items():
+            if aid == current:
+                continue
+            if self.rule.check(fv["neighbor_rsrs"][current], rsrp, now):
+                return aid
+        return None
+
+    # ------------------------------------------------------------------
+    def decide_and_apply(self, ue_id: str):
+        """Select the best antenna and apply the handover."""
+        target = self._select_ml(ue_id) if self.use_ml else self._select_rule(ue_id)
+        if not target:
+            return None
+        return self.state_mgr.apply_handover_decision(ue_id, target)

--- a/5g-network-optimization/services/nef-emulator/tests/test_handover_engine.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_handover_engine.py
@@ -1,0 +1,55 @@
+import sys, os
+from datetime import datetime, timedelta
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+
+from backend.app.app.handover.engine import HandoverEngine
+from backend.app.app.network.state_manager import NetworkStateManager
+
+class DummyAntenna:
+    def __init__(self, rsrp):
+        self._rsrp = rsrp
+    def rsrp_dbm(self, pos):
+        return self._rsrp
+
+def patch_time(monkeypatch, times):
+    import backend.app.app.handover.engine as eng
+    it = iter(times)
+    class FakeDT(datetime):
+        @classmethod
+        def utcnow(cls):
+            return next(it)
+    monkeypatch.setattr(eng, 'datetime', FakeDT)
+
+def test_rule_based_handover(monkeypatch):
+    base = datetime(2025,1,1)
+    times = [base, base + timedelta(seconds=1.1)]
+    patch_time(monkeypatch, times)
+
+    nsm = NetworkStateManager()
+    nsm.antenna_list = {'A': DummyAntenna(-80), 'B': DummyAntenna(-76)}
+    nsm.ue_states = {'u1': {'position': (0,0,0), 'connected_to': 'A'}}
+
+    eng = HandoverEngine(nsm, use_ml=False, a3_hysteresis_db=3.0, a3_ttt_s=1.0)
+    assert eng.decide_and_apply('u1') is None
+    ev = eng.decide_and_apply('u1')
+    assert ev and nsm.ue_states['u1']['connected_to']=='B'
+
+def test_ml_handover(monkeypatch):
+    class DummyModel:
+        def __init__(self, *args, **kwargs):
+            pass
+        def extract_features(self, d):
+            return {}
+        def predict(self, f):
+            return {'antenna_id': 'B', 'confidence': 1.0}
+    monkeypatch.setattr('backend.app.app.handover.engine.AntennaSelector', DummyModel)
+
+    nsm = NetworkStateManager()
+    nsm.antenna_list = {'A': DummyAntenna(-80), 'B': DummyAntenna(-76)}
+    nsm.ue_states = {'u1': {'position': (0,0,0), 'connected_to': 'A', 'speed':0.0}}
+
+    eng = HandoverEngine(nsm, use_ml=True)
+    ev = eng.decide_and_apply('u1')
+    assert ev and ev['to']=='B'


### PR DESCRIPTION
## Summary
- add a flexible `HandoverEngine` for ML and A3 rule handovers
- route `/handover` through new engine
- test engine behaviour for both rule-based and ML modes

## Testing
- `pytest tests/test_handover_engine.py tests/test_state_manager.py::test_apply_handover_decision -q`

------
https://chatgpt.com/codex/tasks/task_e_68568334c0888333824e3765ea692ef9

## Summary by Sourcery

Introduce a unified handover engine that selects and applies antenna handovers via ML or rule-based logic, integrate it into the existing ML API endpoint, and cover both modes with automated tests.

New Features:
- Add HandoverEngine to encapsulate ML and A3 rule-based handover logic with automatic mode selection

Enhancements:
- Route the /api/v1/ml/handover endpoint through HandoverEngine and remove the explicit target antenna parameter
- Return 400 when no handover is triggered and map missing UE errors to 404

Tests:
- Add unit tests for rule-based handover behavior using A3EventRule
- Add unit tests for ML-driven handover behavior with a dummy AntennaSelector