### PR TITLE
Rename feature vector key

### DIFF
--- a/5g-network-optimization/services/conftest.py
+++ b/5g-network-optimization/services/conftest.py
@@ -15,6 +15,9 @@ for path in reversed([NEF_APP_ROOT, NEF_BACKEND_ROOT, NEF_ROOT]):
 import types
 crud_stub = types.ModuleType("crud")
 crud_stub.crud_mongo = object()
+crud_stub.ue = object()
+crud_stub.user = object()
+crud_stub.gnb = object()
 sys.modules.setdefault("app.crud", crud_stub)
 
 # Provide lightweight settings for tests avoiding env var requirements
@@ -24,6 +27,13 @@ settings_stub = types.SimpleNamespace(
     FIRST_SUPERUSER="admin@example.com",
     FIRST_SUPERUSER_PASSWORD="password",
     EMAIL_TEST_USER="test@example.com",
+    SQLALCHEMY_DATABASE_URI="postgresql://user:pass@localhost/testdb",
+    MONGO_CLIENT="mongodb://localhost:27017",
 )
+class QoSSettings:
+    def retrieve_settings(self):
+        return {}
+
+config_stub.qosSettings = QoSSettings()
 config_stub.settings = settings_stub
 sys.modules.setdefault("app.core.config", config_stub)

--- a/5g-network-optimization/services/ml-service/tests/test_ml_components.py
+++ b/5g-network-optimization/services/ml-service/tests/test_ml_components.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 from sklearn.model_selection import train_test_split
 import importlib.util
 from pathlib import Path
+import os
 
 ANT_PATH = Path(__file__).resolve().parents[1] / "app" / "models" / "antenna_selector.py"
 spec = importlib.util.spec_from_file_location("antenna_selector", ANT_PATH)

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/handover/engine.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/handover/engine.py
@@ -47,10 +47,10 @@ class HandoverEngine:
         fv = self.state_mgr.get_feature_vector(ue_id)
         rf_metrics = {
             aid: {
-                "rsrp": fv["neighbor_rsrs"][aid],
+                "rsrp": fv["neighbor_rsrp_dbm"][aid],
                 "sinr": fv["neighbor_sinrs"][aid],
             }
-            for aid in fv["neighbor_rsrs"]
+            for aid in fv["neighbor_rsrp_dbm"]
         }
         ue_data = {
             "ue_id": ue_id,
@@ -69,10 +69,10 @@ class HandoverEngine:
         fv = self.state_mgr.get_feature_vector(ue_id)
         current = fv["connected_to"]
         now = datetime.utcnow()
-        for aid, rsrp in fv["neighbor_rsrs"].items():
+        for aid, rsrp in fv["neighbor_rsrp_dbm"].items():
             if aid == current:
                 continue
-            if self.rule.check(fv["neighbor_rsrs"][current], rsrp, now):
+            if self.rule.check(fv["neighbor_rsrp_dbm"][current], rsrp, now):
                 return aid
         return None
 

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/network/state_manager.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/network/state_manager.py
@@ -84,7 +84,7 @@ class NetworkStateManager:
             'altitude':     z,
             'speed':        speed,
             'connected_to': connected,
-            'neighbor_rsrs': rsrp_dbm,
+            'neighbor_rsrp_dbm': rsrp_dbm,
             'neighbor_sinrs': neighbor_sinrs,
         }
         return features

--- a/5g-network-optimization/services/nef-emulator/tests/integration/test_handover_e2e.py
+++ b/5g-network-optimization/services/nef-emulator/tests/integration/test_handover_e2e.py
@@ -51,8 +51,8 @@ def test_end_to_end_handover(monkeypatch):
         "direction": (0, 0, 0),
         "connected_to": fv["connected_to"],
         "rf_metrics": {
-            aid: {"rsrp": fv["neighbor_rsrs"][aid], "sinr": fv["neighbor_sinrs"][aid]}
-            for aid in fv["neighbor_rsrs"]
+            aid: {"rsrp": fv["neighbor_rsrp_dbm"][aid], "sinr": fv["neighbor_sinrs"][aid]}
+            for aid in fv["neighbor_rsrp_dbm"]
         },
     }
 

--- a/5g-network-optimization/services/nef-emulator/tests/test_state_manager.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_state_manager.py
@@ -28,9 +28,9 @@ def nsm():
 def test_get_feature_vector(nsm):
     fv = nsm.get_feature_vector('ue1')
     assert fv['ue_id'] == 'ue1'
-    assert 'latitude' in fv and 'neighbor_rsrs' in fv
-    # Check that both antennas are present in neighbor_rsrs
-    assert set(fv['neighbor_rsrs'].keys()) == {'antA','antB'}
+    assert 'latitude' in fv and 'neighbor_rsrp_dbm' in fv
+    # Check that both antennas are present in neighbor_rsrp_dbm
+    assert set(fv['neighbor_rsrp_dbm'].keys()) == {'antA','antB'}
 
 def test_apply_handover_decision(nsm):
     ev = nsm.apply_handover_decision('ue1', 'antB')


### PR DESCRIPTION
## Summary
- rename `neighbor_rsrs` feature key to `neighbor_rsrp_dbm`
- update the handover engine to consume the new key
- adjust tests to match the renamed field
- stub config modules and database attributes so tests run without extra env vars

## Testing
- `pytest 5g-network-optimization/services/nef-emulator/tests/test_state_manager.py -q`
- `pytest 5g-network-optimization/services/ml-service/tests/test_ml_components.py::test_model_training_and_prediction -q`
- `pytest -q` *(fails: ImportError: No module named 'evolved5g')*


------
https://chatgpt.com/codex/tasks/task_e_6856b5462540833395088f1c5a7cabca

## Summary by Sourcery

Apply a global rename of the feature vector key from neighbor_rsrs to neighbor_rsrp_dbm and enhance test setup to run without external dependencies

Enhancements:
- Rename feature vector field neighbor_rsrs to neighbor_rsrp_dbm in state manager and handover engine logic

Tests:
- Update unit and integration tests to use neighbor_rsrp_dbm instead of neighbor_rsrs
- Stub CRUD modules, configuration settings, and database URIs for environment-agnostic testing
- Add necessary imports in ML component tests to support test execution