### PR TITLE
Improve integration test handling and docs

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -240,7 +240,14 @@ curl -X POST http://localhost:5050/api/predict \
 
 ### Extended Integration Tests
 
-To run the full integration suite for both services:
+These tests communicate with the running NEF emulator and ML service. Start both
+containers first (for example using `docker-compose`):
+
+```bash
+ML_HANDOVER_ENABLED=1 docker-compose up --build
+```
+
+Then run the full integration suite:
 
 ```bash
 pip install -r requirements.txt

--- a/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
+++ b/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
@@ -4,6 +4,15 @@ import json
 import time
 import importlib.util
 from pathlib import Path
+import pytest
+
+
+def _service_running(url: str) -> bool:
+    try:
+        r = requests.get(url, timeout=2)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
 
 NEF_COLLECTOR_PATH = Path(__file__).resolve().parents[2] / "app" / "data" / "nef_collector.py"
 spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
@@ -13,6 +22,8 @@ NEFDataCollector = nef_collector.NEFDataCollector
 
 def test_nef_connection():
     """Test connecting to the NEF emulator."""
+    if not _service_running("http://localhost:8080/docs"):
+        pytest.skip("NEF emulator is not running")
     print("Testing NEF emulator connection...")
     
     # Try to connect to NEF API
@@ -51,6 +62,8 @@ def test_nef_connection():
 
 def test_data_collection(duration=10):
     """Test collecting data from the NEF emulator."""
+    if not _service_running("http://localhost:8080/docs"):
+        pytest.skip("NEF emulator is not running")
     print(f"\nTesting data collection for {duration} seconds...")
     
     # Initialize collector
@@ -94,6 +107,8 @@ def test_data_collection(duration=10):
 
 def test_ml_prediction_with_nef_data():
     """Test making predictions with data from NEF emulator."""
+    if not _service_running("http://localhost:8080/docs") or not _service_running("http://localhost:5050/docs"):
+        pytest.skip("Required services are not running")
     print("\nTesting ML prediction with NEF data...")
     
     # Check if we have collected data
@@ -125,6 +140,8 @@ def test_ml_prediction_with_nef_data():
 
 def test_end_to_end_flow():
     """Test the complete end-to-end flow."""
+    if not _service_running("http://localhost:8080/docs") or not _service_running("http://localhost:5050/docs"):
+        pytest.skip("Required services are not running")
     print("\nTesting end-to-end flow (NEF → ML Service → Prediction)...")
     
     # Step 1: Connect to NEF

--- a/5g-network-optimization/services/nef-emulator/tests/integration/test_handover_e2e.py
+++ b/5g-network-optimization/services/nef-emulator/tests/integration/test_handover_e2e.py
@@ -7,6 +7,11 @@ from fastapi.testclient import TestClient
 import importlib.util
 from pathlib import Path
 
+try:
+    import sqlalchemy  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency for integration test
+    sqlalchemy = None
+
 ML_DIR = Path(__file__).resolve().parents[3] / "ml-service" / "app" / "__init__.py"
 spec = importlib.util.spec_from_file_location("ml_app_pkg", ML_DIR)
 ml_app_pkg = importlib.util.module_from_spec(spec)
@@ -29,6 +34,9 @@ def _setup_environment(monkeypatch):
 
 
 def test_end_to_end_handover(monkeypatch):
+    if sqlalchemy is None:
+        pytest.skip("SQLAlchemy not available")
+
     ml_api = _setup_environment(monkeypatch)
 
     from app.main import app as nef_app

--- a/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_api.py
+++ b/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_api.py
@@ -3,9 +3,20 @@ import requests
 import json
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
+
+
+def _nef_running() -> bool:
+    try:
+        r = requests.get("http://localhost:8080/docs", timeout=2)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
 
 def test_generate_linear_pattern():
     """Test generating a linear mobility pattern through the API."""
+    if not _nef_running():
+        pytest.skip("NEF emulator is not running")
     url = "http://localhost:8080/api/v1/mobility-patterns/generate"
     
     # Login to get token

--- a/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_integration.py
+++ b/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_integration.py
@@ -1,9 +1,20 @@
 import requests
 import json
 import matplotlib.pyplot as plt
+import pytest
+
+
+def _nef_running() -> bool:
+    try:
+        r = requests.get("http://localhost:8080/docs", timeout=2)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
 
 def test_generate_linear_pattern():
     """Test generating a linear mobility pattern through the API"""
+    if not _nef_running():
+        pytest.skip("NEF emulator is not running")
     url = "http://localhost:8080/api/v1/mobility-patterns/generate"
     
     # API request


### PR DESCRIPTION
## Summary
- add runtime checks in integration tests to skip when services aren't running
- skip e2e handover test when optional deps missing
- document how to start services before running integration suite

## Testing
- `pytest services/nef-emulator/tests/integration services/ml-service/tests/integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f1c8fdfc83339acd00ab435b6ffb