### PR TITLE
Update Kubernetes docs

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -65,6 +65,22 @@ curl -X POST http://localhost:5050/api/predict \
      -d '{"ue_id":"u1","latitude":100,"longitude":50,"connected_to":"antenna_1","rf_metrics":{"antenna_1":{"rsrp":-80,"sinr":15},"antenna_2":{"rsrp":-90,"sinr":10}}}'
 ```
 
+## Building Docker Images
+
+Build the NEF emulator and ML service images before deploying to Kubernetes:
+
+```bash
+docker build -t <registry>/nef-emulator:latest -f services/nef-emulator/backend/Dockerfile.backend services/nef-emulator
+docker build -t <registry>/ml-service:latest services/ml-service
+```
+
+Push the images so your cluster can pull them:
+
+```bash
+docker push <registry>/nef-emulator:latest
+docker push <registry>/ml-service:latest
+```
+
 ## Testing
 First install the dependencies using the repository root `requirements.txt`. Some packages (e.g. `tables`) require system libraries such as `libhdf5-dev` on Ubuntu.
 ```bash

--- a/5g-network-optimization/deployment/kubernetes/README.md
+++ b/5g-network-optimization/deployment/kubernetes/README.md
@@ -8,22 +8,16 @@ This folder contains Kubernetes manifests and tips for running the NEF emulator 
 - Docker images for both services available in your registry
 - `kubectl` configured to access your cluster
 
+## Environment Variables
+
+Both deployments rely on the variables listed in the [root README](../../README.md#environment-variables).
+Define them via `kubectl set env` or by editing the manifests before applying.
+
 ## 1. Build and Push Images
 
-From the repository root build the images and push them to a registry accessible by your cluster:
-
-```bash
-# Build NEF emulator image
-docker build -t <registry>/nef-emulator:latest -f services/nef-emulator/backend/Dockerfile.backend services/nef-emulator
-# Build ML service image
-docker build -t <registry>/ml-service:latest services/ml-service
-# Push images
-docker push <registry>/nef-emulator:latest
-docker push <registry>/ml-service:latest
-```
-
-Update `ml-service.yaml` to use the registry paths. Edit the `image` field under
-`spec.template.spec.containers` so the Deployment pulls your pushed image.
+Build the Docker images and push them to a registry accessible by your cluster.
+Refer to the [root README](../../README.md#building-docker-images) for the exact commands.
+Update `ml-service.yaml` and any NEF emulator manifest to use the registry image paths.
 
 ## 2. Deploy the NEF Emulator
 
@@ -76,11 +70,12 @@ kubectl get pods
 kubectl get services
 ```
 
-The ML service exposes port 5050 inside the cluster. Use port forwarding to access it locally if needed:
+Use port forwarding to access the services locally if needed:
 
 ```bash
+kubectl port-forward svc/nef-emulator 8080:80
 kubectl port-forward svc/ml-service 5050:5050
 ```
 
-You can now send API requests to the ML service while it communicates with the NEF emulator in your cluster.
+You can now send API requests to either service from your workstation.
 


### PR DESCRIPTION
## Summary
- document Docker image build commands in root README
- reference env variables, image build and port-forwarding in k8s deployment guide

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685742eacb048333bbfcea1b2b44207d

## Summary by Sourcery

Update Kubernetes documentation to reference centralized environment variable and Docker image build instructions from the root README, refine deployment manifest guidance, and improve port-forwarding instructions.

Enhancements:
- Consolidate Docker image build and push commands into the root README under a new "Building Docker Images" section
- Reference environment variables and image-building instructions in the Kubernetes deployment guide instead of inline commands
- Instruct users to update Kubernetes manifests with registry image paths for ML service and NEF emulator
- Generalize port-forwarding steps to access both services locally