### PR TITLE
Improve NEF documentation

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -28,6 +28,19 @@ This project aims to optimize 5G handover decisions using a 3GPP-compliant Netwo
 ```
 For detailed setup instructions, see the READMEs in [`services/nef-emulator`](services/nef-emulator/README.md) and [`services/ml-service`](services/ml-service/README.md).
 
+## Mobility Models and A3 Handover
+The emulator includes several 3GPP-compliant mobility models located under
+`services/nef-emulator/backend/app/app/mobility_models`:
+
+- **Linear** and **L‑shaped** movement
+- **Random Waypoint** and **Random Directional**
+- **Manhattan Grid** and **Urban Grid** patterns
+- **Reference Point Group** mobility for UE clusters
+
+For rule-based scenarios the NEF implements the 3GPP **A3 event** rule. Enable
+it with `SIMPLE_MODE=true`; use `A3_HYSTERESIS_DB` and `A3_TTT_S` to tune the
+hysteresis and time-to-trigger parameters.
+
 ## Environment Variables
 The NEF emulator's `NetworkStateManager` supports several configuration options. Set these variables in your shell or through `docker-compose`:
 

--- a/5g-network-optimization/services/nef-emulator/README.md
+++ b/5g-network-optimization/services/nef-emulator/README.md
@@ -17,7 +17,9 @@
 
 **Host prerequisites**: `Docker version 23.0.1`, `Docker Compose v2`, `build-essential`\*, `jq`\*\*
 
-After cloning the repository, there are 4 more steps to do. For convinience, we have created a [`Makefile`](Makefile) that contains a command for each step + several common `docker-compose` tasks which you may find handy in the future.
+After cloning the repository, there are four steps to get the emulator running.
+You can use the provided [`Makefile`](Makefile) or invoke the `docker compose`
+commands manually.
 
 1. create your local `.env` file
 2. build the container images
@@ -38,6 +40,15 @@ make up
 
 # 4.
 make db-init
+```
+
+If you prefer to run the stack without `make`, execute the equivalent commands
+from this directory:
+
+```bash
+# create your .env file (see `backend/app/app/core/config.py` for variables)
+docker compose build
+docker compose up
 ```
 
 >\* 💡 Info: *To use the `make` command you need to `apt install build-essential` first. In case you don't want to proceed with this installation, you can head over to the `Makefile` and copy/paste the shell commands that are being used for every step.*
@@ -75,7 +86,11 @@ Short reasoning on why we choose tags over branches:
 
 ## ↔️ NetApp communication options
 
-To be updated...
+NetApps interact with the emulator via the REST endpoints exposed on
+`http://localhost:8090` (HTTP) and `https://localhost:4443` (HTTPS) by the
+`reverse_proxy` service. When running under Docker Compose, other containers can
+reach the API using the hostname `backend`. Example requests for subscriptions
+and location reporting are available under [`docs/test_plan`](docs/test_plan).
 
 ## Integration with CAPIF
 

--- a/5g-network-optimization/services/nef-emulator/backend/app/nef_integration_guide.md
+++ b/5g-network-optimization/services/nef-emulator/backend/app/nef_integration_guide.md
@@ -4,6 +4,12 @@
 
 This guide explains how to use our 3GPP-compliant mobility models with the existing NEF emulator without modifying its code.
 
+### Available Mobility Models
+- Linear and L-shaped paths
+- Random Waypoint and Random Directional movement
+- Manhattan Grid and Urban Grid models
+- Reference Point Group mobility
+
 ## Step 1: Generate Path Points
 
 Use our mobility models to generate path points in the NEF-compatible format:
@@ -80,3 +86,8 @@ start_data = {"supi": "your_ue_supi"}  # Get SUPI from your UE
 start_response = requests.post(start_url, json=start_data, headers=headers)
 print("UE movement started")
 ```
+
+### A3 Rule-Based Handover
+The emulator supports a basic 3GPP Event A3 rule. Set the environment variable
+`SIMPLE_MODE=true` to enable it and adjust `A3_HYSTERESIS_DB` and `A3_TTT_S` to
+control the hysteresis and time-to-trigger.


### PR DESCRIPTION
## Summary
- explain available mobility models and the A3 event rule
- clarify emulator setup steps and docker-compose usage
- describe NetApp communication options

## Testing
- `pip install -r requirements.txt` *(fails: dependency resolution issues)*
- `pytest -q` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685742e2178c83339f031dfcb590bbbb

## Summary by Sourcery

Enhance NEF emulator documentation with clearer setup instructions, detail available mobility models and A3 handover rules, and describe NetApp communication options

Documentation:
- Clarify emulator setup steps with both Makefile and manual Docker Compose commands
- Describe NetApp REST endpoints and hostname for HTTP/HTTPS communication with example requests
- Add detailed list of available mobility models in root README and integration guide
- Document enabling and tuning of the 3GPP A3 event rule via environment variables