### PR TITLE
Add monitoring documentation

### DIFF
--- a/5g-network-optimization/deployment/kubernetes/README.md
+++ b/5g-network-optimization/deployment/kubernetes/README.md
@@ -79,3 +79,20 @@ kubectl port-forward svc/ml-service 5050:5050
 
 You can now send API requests to either service from your workstation.
 
+## 5. Monitoring with Prometheus and Grafana
+
+The `monitoring/` folder in the repository provides configuration for Prometheus and Grafana. Prometheus scrapes metrics from both services at their `/metrics` endpoints, as shown in `monitoring/prometheus/prometheus.yml`. Grafana connects to the Prometheus service and ships with a sample dashboard for the ML service.
+
+To run the monitoring stack inside your cluster you can create Deployments using these configurations or reuse the existing Docker Compose setup for local testing. Make sure the scrape targets in `prometheus.yml` match the service names used in your manifests.
+
+## Exposing Services
+
+Both `ml-service` and `nef-emulator` are published as ClusterIP services by default. To access them from outside the cluster you can either create `NodePort` services or configure an Ingress controller:
+
+```bash
+# Example NodePort exposure
+kubectl expose deployment ml-service --type=NodePort --port=5050
+kubectl expose deployment nef-emulator --type=NodePort --port=8080
+```
+
+With an Ingress controller installed, update the manifests with ingress rules pointing at the corresponding services. This is the preferred approach in production environments.

--- a/5g-network-optimization/monitoring/README.md
+++ b/5g-network-optimization/monitoring/README.md
@@ -1,0 +1,30 @@
+# Monitoring Stack
+
+This directory contains configuration for Prometheus and Grafana used during development. When `docker-compose` is started from the project root, these services collect metrics from the NEF emulator and the ML service.
+
+## Prometheus
+
+Prometheus scrapes the `/metrics` endpoint exposed by each service. The scrape targets are defined in `prometheus/prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: "ml_service"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["ml-service:5050"]
+  - job_name: "nef_emulator"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["nef-emulator:8080"]
+```
+
+The configuration also includes a job for Prometheus itself. Adjust the targets if the service names or ports change.
+
+Start Prometheus with Docker Compose, or run the container manually and mount this directory at `/etc/prometheus`.
+
+## Grafana
+
+Grafana reads data from Prometheus and provides dashboards. The sample dashboard under `grafana/dashboards/ml_service.json` visualizes request latency, prediction counts and training statistics from the ML service. When Grafana is launched via Docker Compose it automatically picks up dashboards from `grafana/dashboards`.
+
+Login with the default admin credentials (`admin` / `admin`) and add the Prometheus data source at `http://prometheus:9090` if it is not preconfigured. You can then import or customize dashboards to monitor additional metrics.
+


### PR DESCRIPTION
## Summary
- document monitoring stack usage
- expand Kubernetes README with Prometheus/Grafana info and service exposure guidance

## Testing
- `pip install numpy requests matplotlib httpx pytest`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685847c8671c83338eb3d606aad4df0f