### PR TITLE
Fix docs overview heading

### DIFF
--- a/5g-network-optimization/docs/overview.md
+++ b/5g-network-optimization/docs/overview.md
@@ -1,5 +1,3 @@
-Take a breath and think it, take your time, we are not in rush, I give you permission to access and install whatever you want, I want quality and precision.
-
 # Project Overview
 
 This document summarizes the architecture and deployment workflow of the 5G Network Optimization system.  The repository contains two main services:


### PR DESCRIPTION
## Summary
- remove the temporary introductory sentence from `docs/overview.md`

Documentation:
- Remove the placeholder introductory sentence from docs/overview.md