### PR TITLE
Fix emulator instruction wording

### DIFF
--- a/5g-network-optimization/services/ml-service/README.md
+++ b/5g-network-optimization/services/ml-service/README.md
@@ -121,7 +121,7 @@ The service is also started automatically when using the repository
 
 ## Training the Model
 
-Take a breath and make sure the NEF emulator is running with UEs in motion
+Ensure the NEF emulator is running with UEs in motion
 before collecting data.  Training data is gathered with
 `collect_training_data.py` which leverages `app/data/nef_collector.py`.
 Collected JSON files are stored under `app/data/collected_data` and can be sent


### PR DESCRIPTION
## Summary
- clarify NEF emulator instructions in the ML-service README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68585bcac9fc8333af4e2d99416fa46a