### PR TITLE
Add .env template

### DIFF
--- a/5g-network-optimization/.env
+++ b/5g-network-optimization/.env
@@ -1,0 +1,71 @@
+# copy this file to .env
+# cp env-file-for-local.dev .env
+
+DOMAIN=localhost
+DOCKER_IMAGE_BACKEND=dimfrag/nef-backend
+BACKEND_TAG=1.0
+DOCKER_IMAGE_FRONTEND=frontend
+# Backend
+SERVER_NAME=localhost
+SERVER_HOST=localhost
+SERVER_PORT=8888
+BACKEND_CORS_ORIGINS=["https://5g-api-emulator.medianetlab.eu","http://localhost"]
+PROJECT_NAME=NEF_Emulator
+SECRET_KEY=2D47CF2958CEC7CC86C988E9F9684
+FIRST_SUPERUSER=admin@my-email.com
+FIRST_SUPERUSER_PASSWORD=pass
+SMTP_TLS=True
+SMTP_PORT=465
+SMTP_HOST=mail.host.com
+SMTP_USER=user
+SMTP_PASSWORD=pass
+EMAILS_FROM_EMAIL=user@my-email.com
+SENTRY_DSN=
+USERS_OPEN_REGISTRATION=true
+NEF_HOST=3gppnef
+# Postgres
+# info: POSTGRES_USER value ('postgres') is hard-coded in /pgadmin/servers.json
+POSTGRES_SERVER=db
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=pass
+POSTGRES_DB=app
+
+# PgAdmin
+PGADMIN_LISTEN_PORT=5050
+PGADMIN_DEFAULT_EMAIL=admin@my-email.com
+PGADMIN_DEFAULT_PASSWORD=pass
+
+# Mongo 
+MONGO_USER=root
+MONGO_PASSWORD=pass
+MONGO_CLIENT=mongodb://mongo_nef:27017/
+
+# MongoExpress
+MONGO_EXPRESS_ENABLE_ADMIN=true
+
+#Nginx
+DOCKER_IMAGE_PROXY=dimfrag/nef-nginx
+PROXY_TAG=1.0
+NGINX_HTTP=8090
+NGINX_HTTPS=4443
+NGINX_HOST=127.0.0.1
+
+# CAPIF
+# Compose Networking 
+# If CAPIF CORE FUNCTION is up and running set EXTERNAL_NET to true 
+# Else if NEF is used as a standalone service set EXTERNAL_NET to false
+
+CAPIF_HOST=capifcore
+CAPIF_HTTP_PORT=8080
+CAPIF_HTTPS_PORT=443
+EXTERNAL_NET=true
+
+#Public Certificate for verifing access token
+USE_PUBLIC_KEY_VERIFICATION=true
+
+#Service Description files for K8s deployment
+#If you want use domainName in service descritpion files turn production to true and specify the domainName variable
+#Else interfaceDescriptions (ipv4, port) will be used in the service descritpion files declared in NGINX_HOST, NGINX_HTTPS variables
+
+PRODUCTION=true
+DOMAIN_NAME=nefemu.com

--- a/5g-network-optimization/.gitignore
+++ b/5g-network-optimization/.gitignore
@@ -25,7 +25,7 @@ venv/
 ENV/
 
 # Environment variables
-.env
+# .env is tracked for local development
 
 # IDEs
 .idea/


### PR DESCRIPTION
## Summary
- include sample `.env` file for local setup
- keep `.env` under version control

## Testing
- `pip install -r requirements.txt` *(fails: could not find a local HDF5 installation)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68584a656c808333aa536b3814391814