### PR TITLE
Fix dependencies and skip failing visualization tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_visualization.py
+++ b/5g-network-optimization/services/ml-service/tests/test_visualization.py
@@ -3,6 +3,15 @@ import requests
 from PIL import Image
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
+
+
+def _service_available(url: str) -> bool:
+    try:
+        requests.get(url, timeout=2)
+        return True
+    except Exception:
+        return False
 
 
 def test_coverage_map():
@@ -11,6 +20,9 @@ def test_coverage_map():
     
     # Make request to endpoint
     url = "http://localhost:5050/api/visualization/coverage-map"
+    if not _service_available(url):
+        pytest.skip("ml-service not running")
+
     response = requests.get(url)
     
     # Check response
@@ -64,6 +76,9 @@ def test_trajectory_visualization():
     
     # Make request to endpoint
     url = "http://localhost:5050/api/visualization/trajectory"
+    if not _service_available(url):
+        pytest.skip("ml-service not running")
+
     response = requests.post(url, json=trajectory_data)
     
     # Check response

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Jinja2==3.1.2
 Markdown==3.3.7
 aiofiles==0.6.0
-aiohttp==3.8.1
+aiohttp==3.9.3
 asyncio-throttle==1.0.2
 autoflake==1.3.1
 black==21.12b0
@@ -18,8 +18,8 @@ google-auth==2.31.0
 google-cloud-core==2.4.1
 google-cloud-secret-manager==2.20.0
 google-cloud-storage==2.17.0
-grpcio==1.38.1
-grpcio-tools==1.38.1
+grpcio==1.59.0
+grpcio-tools==1.59.0
 gunicorn==20.1.0
 hyperopt==0.2.7
 isort==5.13.2
@@ -28,7 +28,7 @@ lightgbm==3.1.1
 markdown2==2.4.3
 matplotlib==3.5.2
 mypy==0.910
-numpy==1.19.5
+numpy>=1.19.5
 pandas==2.2.3
 passlib[bcrypt]==1.7.4
 psycopg2-binary==2.8.5
@@ -48,7 +48,6 @@ scikit-learn==1.5.2
 seaborn==0.13.2
 sqlalchemy==1.3.16
 sqlalchemy-stubs==0.3
-tables==3.7.0
 tenacity==6.3.1
 umap-learn==0.5.3
 uvicorn==0.17.6


### PR DESCRIPTION
## Summary
- update requirements to use modern packages compatible with Python 3.11
- skip visualization tests when ml-service is not running

Update project dependencies for Python 3.11 compatibility and add a service availability guard to skip failing visualization tests when the ml-service endpoint is not running.

Build:
- Upgrade requirements.txt to modern package versions (including aiohttp, grpcio, numpy, etc.) compatible with Python 3.11

Tests:
- Add a helper to check ml-service availability and skip visualization tests if the service is not running