### PR TITLE
Improve ml-service tests for offline execution

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/conftest.py
+++ b/5g-network-optimization/services/ml-service/tests/conftest.py
@@ -1,0 +1,18 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+APP_INIT = Path(__file__).resolve().parents[1] / "app" / "__init__.py"
+spec = importlib.util.spec_from_file_location("ml_app", APP_INIT)
+ml_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ml_app)
+create_app = ml_app.create_app
+
+@pytest.fixture
+def app():
+    app = create_app({'TESTING': True})
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
+++ b/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
@@ -1,18 +1,6 @@
-"""Integration tests for NEF emulator communication."""
-import requests
-import json
-import time
+from unittest.mock import MagicMock, patch
 import importlib.util
 from pathlib import Path
-import pytest
-
-
-def _service_running(url: str) -> bool:
-    try:
-        r = requests.get(url, timeout=2)
-        return r.status_code == 200
-    except requests.RequestException:
-        return False
 
 NEF_COLLECTOR_PATH = Path(__file__).resolve().parents[2] / "app" / "data" / "nef_collector.py"
 spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
@@ -20,209 +8,32 @@ nef_collector = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(nef_collector)
 NEFDataCollector = nef_collector.NEFDataCollector
 
-def test_nef_connection():
-    """Test connecting to the NEF emulator."""
-    if not _service_running("http://localhost:8080/docs"):
-        pytest.skip("NEF emulator is not running")
-    print("Testing NEF emulator connection...")
-    
-    # Try to connect to NEF API
-    try:
-        # First, check if NEF emulator is running
-        response = requests.get("http://localhost:8080/docs", timeout=2)
-        if response.status_code != 200:
-            print("❌ NEF emulator does not appear to be running or is not accessible")
-            print("Please start the NEF emulator and try again")
-            return False
-        
-        # Initialize collector with credentials (adjust as needed)
-        collector = NEFDataCollector(
-            nef_url="http://localhost:8080",
-            username="admin",
-            password="admin"  # Change to match your NEF emulator credentials
-        )
-        
-        # Attempt to login
-        success = collector.login()
-        if success:
-            print("✅ Successfully connected to NEF emulator")
-        else:
-            print("❌ Failed to authenticate with NEF emulator")
-            print("Check your credentials and NEF emulator status")
-            return False
-        
-        return True
-    except requests.exceptions.ConnectionError:
-        print("❌ Connection error - NEF emulator is not running or not accessible")
-        print("Please start the NEF emulator and try again")
-        return False
-    except Exception as e:
-        print(f"❌ Unexpected error during NEF connection test: {str(e)}")
-        return False
 
-def test_data_collection(duration=10):
-    """Test collecting data from the NEF emulator."""
-    if not _service_running("http://localhost:8080/docs"):
-        pytest.skip("NEF emulator is not running")
-    print(f"\nTesting data collection for {duration} seconds...")
-    
-    # Initialize collector
-    collector = NEFDataCollector(
-        nef_url="http://localhost:8080",
-        username="admin",
-        password="admin"  # Change to match your NEF emulator credentials
-    )
-    
-    # Login
-    if not collector.login():
-        print("❌ Login failed - skipping data collection test")
-        return False
-    
-    # Get current UE movement state
-    ue_state = collector.get_ue_movement_state()
-    
-    if not ue_state:
-        print("❌ No UEs in movement state found")
-        print("Please start UE movement in the NEF emulator before running this test")
-        return False
-    
-    print(f"✅ Found {len(ue_state)} UEs in movement")
-    
-    # Collect data for specified duration
-    print(f"Collecting data for {duration} seconds...")
-    data = collector.collect_training_data(duration=duration, interval=1)
-    
-    if not data:
-        print("❌ No data collected")
-        return False
-    
-    print(f"✅ Successfully collected {len(data)} data points")
-    
-    # Save sample to test file
-    with open("test_collected_data.json", "w") as f:
-        json.dump(data[:10], f, indent=2)  # Save first 10 samples
-    
-    print("✅ Sample data saved to test_collected_data.json")
-    return True
+def test_login_success():
+    collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
+    mock_resp = MagicMock(status_code=200, json=lambda: {"access_token": "tok"})
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        assert collector.login() is True
+        assert collector.token == "tok"
+        mock_post.assert_called_once()
 
-def test_ml_prediction_with_nef_data():
-    """Test making predictions with data from NEF emulator."""
-    if not _service_running("http://localhost:8080/docs") or not _service_running("http://localhost:5050/docs"):
-        pytest.skip("Required services are not running")
-    print("\nTesting ML prediction with NEF data...")
-    
-    # Check if we have collected data
-    try:
-        with open("test_collected_data.json", "r") as f:
-            data = json.load(f)
-        
-        if not data:
-            print("❌ No data available for prediction test")
-            return False
-        
-        # Make prediction request to ML service
-        url = "http://localhost:5050/api/predict"
-        response = requests.post(url, json=data[0])
-        
-        if response.status_code == 200:
-            result = response.json()
-            print("✅ Prediction successful")
-            print(f"UE: {result.get('ue_id')}")
-            print(f"Predicted antenna: {result.get('predicted_antenna')}")
-            print(f"Confidence: {result.get('confidence')}")
-            return True
-        else:
-            print(f"❌ Prediction failed: {response.status_code} - {response.text}")
-            return False
-    except Exception as e:
-        print(f"❌ Error during prediction test: {str(e)}")
-        return False
 
-def test_end_to_end_flow():
-    """Test the complete end-to-end flow."""
-    if not _service_running("http://localhost:8080/docs") or not _service_running("http://localhost:5050/docs"):
-        pytest.skip("Required services are not running")
-    print("\nTesting end-to-end flow (NEF → ML Service → Prediction)...")
-    
-    # Step 1: Connect to NEF
-    if not test_nef_connection():
-        print("❌ NEF connection failed - stopping end-to-end test")
-        return False
-    
-    # Step 2: Collect data (just a few samples)
-    collector = NEFDataCollector(
-        nef_url="http://localhost:8080",
-        username="admin", 
-        password="admin"
-    )
-    collector.login()
-    data = collector.collect_training_data(duration=5, interval=1)
-    
-    if not data:
-        print("❌ No data collected - stopping end-to-end test")
-        return False
-    
-    print(f"✅ Collected {len(data)} samples for end-to-end test")
-    
-    # Step 3: Train model with collected data
-    try:
-        train_url = "http://localhost:5050/api/train"
-        train_response = requests.post(train_url, json=data)
-        
-        if train_response.status_code == 200:
-            print("✅ Training successful")
-            metrics = train_response.json().get('metrics', {})
-            print(f"Trained with {metrics.get('samples', 0)} samples")
-            print(f"Found {metrics.get('classes', 0)} antenna classes")
-        else:
-            print(f"❌ Training failed: {train_response.status_code} - {train_response.text}")
-            # Continue anyway since the model may have a default prediction
-    except Exception as e:
-        print(f"❌ Error during training: {str(e)}")
-        # Continue anyway
-    
-    # Step 4: Make prediction for a UE
-    try:
-        # Get current UE state
-        ue_state = collector.get_ue_movement_state()
-        
-        if not ue_state:
-            print("❌ No UEs available for prediction")
-            return False
-        
-        # Take the first UE
-        ue_id, ue_data = next(iter(ue_state.items()))
-        
-        # Make prediction
-        predict_url = "http://localhost:5050/api/predict"
-        predict_response = requests.post(predict_url, json=ue_data)
-        
-        if predict_response.status_code == 200:
-            result = predict_response.json()
-            print("✅ End-to-end prediction successful")
-            print(f"UE: {result.get('ue_id', ue_id)}")
-            print(f"Position: ({ue_data.get('latitude', 'N/A')}, {ue_data.get('longitude', 'N/A')})")
-            print(f"Connected to: {ue_data.get('Cell_id', 'N/A')}")
-            print(f"Predicted antenna: {result.get('predicted_antenna', 'N/A')}")
-            print(f"Confidence: {result.get('confidence', 'N/A')}")
-            return True
-        else:
-            print(f"❌ End-to-end prediction failed: {predict_response.status_code} - {predict_response.text}")
-            return False
-    except Exception as e:
-        print(f"❌ Error during end-to-end test: {str(e)}")
-        return False
+def test_get_ue_movement_state():
+    collector = NEFDataCollector(nef_url="http://nef")
+    collector.headers = {"Authorization": "Bearer tok"}
+    mock_resp = MagicMock(status_code=200, json=lambda: {"ue1": {"latitude": 1, "longitude": 2}})
+    with patch("requests.get", return_value=mock_resp) as mock_get:
+        state = collector.get_ue_movement_state()
+        assert state["ue1"]["latitude"] == 1
+        mock_get.assert_called_once()
 
-if __name__ == "__main__":
-    print("Running NEF Integration Tests")
-    print("============================")
-    print("Note: These tests require the NEF emulator to be running")
-    print("      and at least one UE with active movement\n")
-    
-    # Run tests only if NEF is available
-    if test_nef_connection():
-        test_data_collection()
-        test_ml_prediction_with_nef_data()
-        test_end_to_end_flow()
-    else:
-        print("\nSkipping remaining tests due to NEF connection failure")
+
+def test_collect_training_data():
+    collector = NEFDataCollector(nef_url="http://nef")
+    sample_state = {"ue1": {"latitude": 0, "longitude": 0, "speed": 1.0, "Cell_id": "A"}}
+    with patch.object(collector, "get_ue_movement_state", return_value=sample_state), \
+         patch("time.sleep"), \
+         patch("time.time", side_effect=[0, 0.1, 1.1]):
+        data = collector.collect_training_data(duration=1, interval=1)
+        assert len(data) == 1
+        assert data[0]["ue_id"] == "ue1"

--- a/5g-network-optimization/services/ml-service/tests/test_routes.py
+++ b/5g-network-optimization/services/ml-service/tests/test_routes.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+
+
+def test_predict_route(client):
+    mock_model = MagicMock()
+    mock_model.extract_features.return_value = {"f": 1}
+    mock_model.predict.return_value = {"antenna_id": "antenna_1", "confidence": 0.9}
+
+    with patch("app.api.routes.model", mock_model):
+        resp = client.post("/api/predict", json={"ue_id": "u1"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["predicted_antenna"] == "antenna_1"
+        assert data["confidence"] == 0.9
+
+
+def test_train_route(client):
+    mock_model = MagicMock()
+    mock_model.train.return_value = {"samples": 1, "classes": 1}
+    mock_model.save.return_value = True
+
+    with patch("app.api.routes.model", mock_model):
+        resp = client.post("/api/train", json=[{"optimal_antenna": "a1"}])
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["metrics"]["samples"] == 1
+        mock_model.train.assert_called_once()
+        mock_model.save.assert_called_once()
+
+
+def test_nef_status(client):
+    mock_response = MagicMock(status_code=200, headers={"X-API-Version": "v1"})
+    with patch("app.api.routes.requests.get", return_value=mock_response) as mock_get:
+        resp = client.get("/api/nef-status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data == {"status": "connected", "nef_version": "v1"}
+        mock_get.assert_called_once()

--- a/5g-network-optimization/services/ml-service/tests/test_visualization.py
+++ b/5g-network-optimization/services/ml-service/tests/test_visualization.py
@@ -1,106 +1,33 @@
-"""Integration tests for visualization endpoints."""
-import requests
-from PIL import Image
-import matplotlib.pyplot as plt
-import numpy as np
-import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import json
 
 
-def _service_available(url: str) -> bool:
-    try:
-        requests.get(url, timeout=2)
-        return True
-    except Exception:
-        return False
+COVERAGE_IMG = Path(__file__).resolve().parents[1] / "test_coverage_map.png"
+TRAJ_IMG = Path(__file__).resolve().parents[1] / "test_trajectory.png"
 
 
-def test_coverage_map():
-    """Test the coverage map endpoint."""
-    print("Testing coverage map visualization...")
-    
-    # Make request to endpoint
-    url = "http://localhost:5050/api/visualization/coverage-map"
-    if not _service_available(url):
-        pytest.skip("ml-service not running")
+def test_coverage_map_endpoint(client):
+    mock_model = MagicMock()
+    mock_model.predict.return_value = {"antenna_id": "a1", "confidence": 1.0}
+    with patch("app.api.visualization.model", mock_model), \
+         patch("app.api.visualization.plot_antenna_coverage", return_value=str(COVERAGE_IMG)):
+        resp = client.get("/api/visualization/coverage-map")
+        assert resp.status_code == 200
+        assert len(resp.data) > 0
 
-    response = requests.get(url)
-    
-    # Check response
-    if response.status_code == 200:
-        print("✅ Successfully received coverage map")
-        
-        # Save the image
-        with open("test_coverage_map.png", "wb") as f:
-            f.write(response.content)
-        
-        # Check if it's a valid image
-        try:
-            img = Image.open("test_coverage_map.png")
-            print(f"✅ Valid image received - Size: {img.size}, Format: {img.format}")
-            return True
-        except Exception as e:
-            print(f"❌ Invalid image: {e}")
-            return False
-    else:
-        print(f"❌ Failed to get coverage map: {response.status_code} - {response.text}")
-        return False
 
-def test_trajectory_visualization():
-    """Test the trajectory visualization endpoint."""
-    print("\nTesting trajectory visualization...")
-    
-    # Generate synthetic trajectory data
-    trajectory_data = []
-    for i in range(50):
-        # Create a zigzag pattern
-        x = i * 20
-        y = 500 if i % 2 == 0 else 300
-        
-        # Assign antenna based on position
-        if i < 20:
-            antenna = "antenna_1"
-        elif i < 40:
-            antenna = "antenna_2"
-        else:
-            antenna = "antenna_3"
-        
-        point = {
-            "ue_id": "test_ue",
-            "timestamp": f"2025-04-17T{10+i//10}:{i%10}0:00",
-            "latitude": x,
-            "longitude": y,
-            "connected_to": antenna,
-            "speed": 2.0
-        }
-        trajectory_data.append(point)
-    
-    # Make request to endpoint
-    url = "http://localhost:5050/api/visualization/trajectory"
-    if not _service_available(url):
-        pytest.skip("ml-service not running")
+def test_trajectory_endpoint(client):
+    movement = [{
+        "ue_id": "u1",
+        "timestamp": "2025-01-01T00:00:00",
+        "latitude": 0,
+        "longitude": 0,
+        "connected_to": "a1",
+        "speed": 1.0
+    }]
 
-    response = requests.post(url, json=trajectory_data)
-    
-    # Check response
-    if response.status_code == 200:
-        print("✅ Successfully received trajectory visualization")
-        
-        # Save the image
-        with open("test_trajectory.png", "wb") as f:
-            f.write(response.content)
-        
-        # Check if it's a valid image
-        try:
-            img = Image.open("test_trajectory.png")
-            print(f"✅ Valid image received - Size: {img.size}, Format: {img.format}")
-            return True
-        except Exception as e:
-            print(f"❌ Invalid image: {e}")
-            return False
-    else:
-        print(f"❌ Failed to get trajectory visualization: {response.status_code} - {response.text}")
-        return False
-
-if __name__ == "__main__":
-    test_coverage_map()
-    test_trajectory_visualization()
+    with patch("app.api.visualization.plot_movement_trajectory", return_value=str(TRAJ_IMG)):
+        resp = client.post("/api/visualization/trajectory", data=json.dumps(movement), content_type="application/json")
+        assert resp.status_code == 200
+        assert len(resp.data) > 0


### PR DESCRIPTION
## Summary
- create app fixture for ml-service tests
- add new tests for `/api` routes using Flask test client
- rewrite visualization tests to use test client and mock plotting
- replace NEF integration tests with offline mocks

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859520af20883338cfd2364d359aaa3

## Summary by Sourcery

Streamline ml-service tests for offline execution by introducing pytest fixtures and Flask test client, refactoring external integration tests to unit tests with mocks, and extending coverage to API, visualization, and NEFDataCollector components.

Enhancements:
- Decouple tests from external NEF emulator and plotting services by mocking HTTP requests and plotting functions.

Tests:
- Add pytest fixtures `app` and `client` for offline Flask test client usage.
- Replace NEF integration tests with unit tests for NEFDataCollector methods using mocks.
- Rewrite visualization endpoint tests to use the Flask test client and mocked plotting utilities.
- Add new tests for `/api/predict`, `/api/train`, and `/api/nef-status` routes with mocked model and HTTP dependencies.