### PR TITLE
Add plotter visualization tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_plotter.py
+++ b/5g-network-optimization/services/ml-service/tests/test_plotter.py
@@ -1,0 +1,44 @@
+import importlib.util
+from pathlib import Path
+import matplotlib
+matplotlib.use("Agg")
+
+# Load plotter module directly to avoid package import issues
+PLOTTER_PATH = Path(__file__).resolve().parents[1] / "app" / "visualization" / "plotter.py"
+spec = importlib.util.spec_from_file_location("plotter", PLOTTER_PATH)
+plotter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(plotter)
+plot_antenna_coverage = plotter.plot_antenna_coverage
+plot_movement_trajectory = plotter.plot_movement_trajectory
+
+
+class DummyAntennaSelector:
+    """Minimal predictor for deterministic results."""
+
+    def extract_features(self, data):
+        return data
+
+    def predict(self, features):
+        return {"antenna_id": "a1", "confidence": 1.0}
+
+
+def _check_png(path: Path):
+    assert path.exists(), f"{path} was not created"
+    with path.open("rb") as fh:
+        signature = fh.read(8)
+    assert signature == b"\x89PNG\r\n\x1a\n", "File is not a valid PNG"
+
+
+def test_plot_functions_generate_png(tmp_path):
+    model = DummyAntennaSelector()
+
+    cov_path = Path(plot_antenna_coverage(model, output_dir=tmp_path))
+    _check_png(cov_path)
+
+    movement = [
+        {"latitude": 0, "longitude": 0, "connected_to": "a1"},
+        {"latitude": 1, "longitude": 1, "connected_to": "a1"},
+        {"latitude": 2, "longitude": 2, "connected_to": "a2"},
+    ]
+    traj_path = Path(plot_movement_trajectory(movement, output_dir=tmp_path))
+    _check_png(traj_path)


### PR DESCRIPTION
## Summary
- add pytest for ML service plotter module
- ensure coverage/trajectory plot functions save PNG files


Tests:
- Add tests for plot_antenna_coverage and plot_movement_trajectory that use a dummy model or sample data and assert output PNG files are created and valid.