### PR TITLE
Add Prometheus metrics tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_metrics.py
+++ b/5g-network-optimization/services/ml-service/tests/test_metrics.py
@@ -1,14 +1,6 @@
-import importlib.util
-from pathlib import Path
 from flask import Flask
 
-METRICS_PATH = Path(__file__).resolve().parents[1] / "app" / "monitoring" / "metrics.py"
-spec = importlib.util.spec_from_file_location("metrics", METRICS_PATH)
-metrics = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(metrics)
-MetricsMiddleware = metrics.MetricsMiddleware
-track_prediction = metrics.track_prediction
-track_training = metrics.track_training
+from app.monitoring.metrics import MetricsMiddleware, track_prediction, track_training
 
 
 def test_metrics_middleware_counts_success():

--- a/5g-network-optimization/services/ml-service/tests/test_metrics.py
+++ b/5g-network-optimization/services/ml-service/tests/test_metrics.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+from flask import Flask
+
+METRICS_PATH = Path(__file__).resolve().parents[1] / "app" / "monitoring" / "metrics.py"
+spec = importlib.util.spec_from_file_location("metrics", METRICS_PATH)
+metrics = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(metrics)
+MetricsMiddleware = metrics.MetricsMiddleware
+track_prediction = metrics.track_prediction
+track_training = metrics.track_training
+
+
+def test_metrics_middleware_counts_success():
+    app = Flask(__name__)
+
+    @app.route("/api/test")
+    def _test():
+        return "ok"
+
+    app.wsgi_app = MetricsMiddleware(app.wsgi_app)
+    client = app.test_client()
+
+    before = metrics.PREDICTION_REQUESTS.labels(status="success")._value.get()
+    resp = client.get("/api/test")
+    assert resp.status_code == 200
+    after = metrics.PREDICTION_REQUESTS.labels(status="success")._value.get()
+    assert after == before + 1
+
+
+def test_track_prediction_updates_metrics():
+    before = metrics.ANTENNA_PREDICTIONS.labels(antenna_id="a1")._value.get()
+    track_prediction("a1", 0.5)
+    after = metrics.ANTENNA_PREDICTIONS.labels(antenna_id="a1")._value.get()
+    confidence = metrics.PREDICTION_CONFIDENCE.labels(antenna_id="a1")._value.get()
+    assert after == before + 1
+    assert confidence == 0.5
+
+
+def test_track_training_updates_metrics():
+    sum_before = metrics.MODEL_TRAINING_DURATION._sum.get()
+    track_training(1.2, 10, accuracy=0.9)
+    sum_after = metrics.MODEL_TRAINING_DURATION._sum.get()
+    samples = metrics.MODEL_TRAINING_SAMPLES._value.get()
+    accuracy = metrics.MODEL_TRAINING_ACCURACY._value.get()
+    assert sum_after == sum_before + 1.2
+    assert samples == 10
+    assert accuracy == 0.9


### PR DESCRIPTION
## Summary
- add metrics tests for ml-service
- verify MetricsMiddleware increments counters
- ensure tracking functions update Prometheus metrics


Add Prometheus metrics tests for the ml-service to ensure the middleware and tracking functions correctly update metrics

Tests:
- Add test to verify MetricsMiddleware increments prediction request counters
- Add test to verify track_prediction updates antenna prediction counts and confidence metrics
- Add test to verify track_training updates model training duration, sample count, and accuracy metrics