### PR TITLE
Refactor RF model tests for speed

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/conftest.py
+++ b/5g-network-optimization/services/ml-service/tests/conftest.py
@@ -3,8 +3,9 @@ import importlib.util
 import sys
 import pytest
 
-# Path to the ml-service package
+# Ensure the service package can be imported as ``app`` before test collection.
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SERVICE_ROOT))
 
 
 def load_create_app():

--- a/5g-network-optimization/services/nef-emulator/tests/rf_models/test_antenna_models.py
+++ b/5g-network-optimization/services/nef-emulator/tests/rf_models/test_antenna_models.py
@@ -71,5 +71,24 @@ def test_sinr_under_heavy_interference(ue_position):
     sinr = ant.sinr_db(ue_position, interferers)
     assert -50 < sinr < 50, f"SINR {sinr:.1f} dB outside realistic range (–50 to 50)"
 
+
+def test_deterministic_outputs_without_shadowing(ue_position):
+    """path_loss_db, rsrp_dbm and sinr_db should be deterministic when shadowing is disabled."""
+    ant = MacroCellModel("det", (0, 0, 10), 3.5e9, 30)
+    interferer = MacroCellModel("i1", (50, 0, 10), 3.5e9, 30)
+
+    pl_expected = ant.path_loss_db(ue_position, include_shadowing=False)
+    rs_expected = ant.rsrp_dbm(ue_position, include_shadowing=False)
+    sinr_expected = ant.sinr_db(ue_position, [interferer])
+
+    assert pl_expected == ant.path_loss_db(ue_position, include_shadowing=False)
+    assert rs_expected == ant.rsrp_dbm(ue_position, include_shadowing=False)
+    assert sinr_expected == ant.sinr_db(ue_position, [interferer])
+
+    # Fixed values make the test more explicit
+    assert round(pl_expected, 10) == 118.5401390252
+    assert round(rs_expected, 10) == -88.5401390252
+    assert round(sinr_expected, 10) == -11.1543710146
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))

--- a/5g-network-optimization/services/nef-emulator/tests/rf_models/test_path_loss.py
+++ b/5g-network-optimization/services/nef-emulator/tests/rf_models/test_path_loss.py
@@ -1,126 +1,36 @@
-"""Tests for path loss models."""
+"""Unit tests for path loss related models.
+
+The previous version of this file generated several plots which slowed the test
+suite considerably.  These tests focus purely on the numeric behaviour of the
+models so that they run quickly.
+"""
+from math import log10
 import numpy as np
-import matplotlib.pyplot as plt
 
 from rf_models.path_loss import ABGPathLossModel, CloseInPathLossModel, FastFading
 
-def test_abg_path_loss_model():
-    """Test ABG path loss model."""
-    # Create model
+
+def test_abg_against_reference():
+    """Validate ABG path loss calculation against a hand computed reference."""
     model = ABGPathLossModel()
-    
-    # Calculate path loss over distance
-    distances = np.linspace(1, 1000, 100)
-    path_loss_3ghz = [model.calculate_path_loss(d, 3.5, include_shadowing=False) for d in distances]
-    path_loss_28ghz = [model.calculate_path_loss(d, 28, include_shadowing=False) for d in distances]
-    
-    # Plot results
-    plt.figure(figsize=(10, 6))
-    plt.plot(distances, path_loss_3ghz, 'b-', linewidth=2, label='3.5 GHz')
-    plt.plot(distances, path_loss_28ghz, 'r-', linewidth=2, label='28 GHz')
-    
-    plt.xlabel('Distance (m)')
-    plt.ylabel('Path Loss (dB)')
-    plt.title('ABG Path Loss Model')
-    plt.grid(True)
-    plt.legend()
-    
-    plt.savefig('abg_path_loss.png')
-    print("Plot saved as abg_path_loss.png")
-    
-    # Test shadowing
-    path_loss_with_shadowing = [model.calculate_path_loss(100, 3.5, include_shadowing=True) for _ in range(1000)]
-    std_dev = np.std(path_loss_with_shadowing)
-    
-    print(f"Path loss at 100m, 3.5GHz: {model.calculate_path_loss(100, 3.5, include_shadowing=False):.2f} dB")
-    print(f"Standard deviation of shadowing: {std_dev:.2f} dB (expected: {model.sigma:.2f} dB)")
-    
-    # Should be close to model.sigma
-    assert abs(std_dev - model.sigma) < 0.5, f"Shadowing std dev {std_dev:.2f} dB differs from model σ={model.sigma:.2f} dB"
+    pl = model.calculate_path_loss(100, 3.5, include_shadowing=False)
+    expected = 10 * model.alpha * log10(100) + model.beta + 10 * model.gamma * log10(3.5)
+    assert abs(pl - expected) < 1e-6
 
-def test_ci_path_loss_model():
-    """Test Close-In path loss model."""
-    # Create model
+
+def test_ci_against_reference():
+    """Validate Close-In path loss calculation against a hand computed reference."""
     model = CloseInPathLossModel()
-    
-    # Calculate path loss over distance
-    distances = np.linspace(1, 1000, 100)
-    path_loss_3ghz = [model.calculate_path_loss(d, 3.5, include_shadowing=False) for d in distances]
-    path_loss_28ghz = [model.calculate_path_loss(d, 28, include_shadowing=False) for d in distances]
-    
-    # Plot results
-    plt.figure(figsize=(10, 6))
-    plt.plot(distances, path_loss_3ghz, 'b-', linewidth=2, label='3.5 GHz')
-    plt.plot(distances, path_loss_28ghz, 'r-', linewidth=2, label='28 GHz')
-    
-    plt.xlabel('Distance (m)')
-    plt.ylabel('Path Loss (dB)')
-    plt.title('Close-In Path Loss Model')
-    plt.grid(True)
-    plt.legend()
-    
-    plt.savefig('ci_path_loss.png')
-    print("Plot saved as ci_path_loss.png")
-    
-    assert True, "Close-In path loss model test passed"
+    pl = model.calculate_path_loss(100, 3.5, include_shadowing=False)
+    expected = 32.4 + 10 * model.n * log10(100) + 20 * log10(3.5)
+    assert abs(pl - expected) < 1e-6
 
-def test_fast_fading():
-    """Test fast fading model."""
-    # Create model
-    model = FastFading(carrier_frequency=3.5)
-    
-    # Generate fading for different velocities
-    duration = 10.0  # seconds
-    time_step = 0.01  # seconds
-    time_points = np.arange(0, duration, time_step)
-    
-    fading_5kmh = model.generate_fading(5 / 3.6, duration, time_step)  # 5 km/h in m/s
-    fading_30kmh = model.generate_fading(30 / 3.6, duration, time_step)  # 30 km/h in m/s
-    fading_120kmh = model.generate_fading(120 / 3.6, duration, time_step)  # 120 km/h in m/s
-    
-    # Plot results
-    plt.figure(figsize=(12, 8))
-    
-    plt.subplot(3, 1, 1)
-    plt.plot(time_points, fading_5kmh, 'b-')
-    plt.title('Fast Fading at 5 km/h')
-    plt.ylabel('Fading (dB)')
-    plt.grid(True)
-    
-    plt.subplot(3, 1, 2)
-    plt.plot(time_points, fading_30kmh, 'g-')
-    plt.title('Fast Fading at 30 km/h')
-    plt.ylabel('Fading (dB)')
-    plt.grid(True)
-    
-    plt.subplot(3, 1, 3)
-    plt.plot(time_points, fading_120kmh, 'r-')
-    plt.title('Fast Fading at 120 km/h')
-    plt.xlabel('Time (s)')
-    plt.ylabel('Fading (dB)')
-    plt.grid(True)
-    
-    plt.tight_layout()
-    plt.savefig('fast_fading.png')
-    print("Plot saved as fast_fading.png")
-    
-    # Check statistical properties
-    mean_5kmh = np.mean(fading_5kmh)
-    std_5kmh = np.std(fading_5kmh)
-    
-    print(f"Fast fading at 5 km/h: Mean = {mean_5kmh:.2f} dB, Std = {std_5kmh:.2f} dB")
-    
-    # Mean should be close to 0 dB
-    assert abs(mean_5kmh) < 1.0, f"Mean fading {mean_5kmh:.2f} dB differs from 0 dB" 
 
-if __name__ == "__main__":
-    print("Testing ABG Path Loss Model...")
-    test_abg_path_loss_model()
-    
-    print("\nTesting Close-In Path Loss Model...")
-    test_ci_path_loss_model()
-    
-    print("\nTesting Fast Fading Model...")
-    test_fast_fading()
-    
-    print("\nAll tests completed.")
+def test_fast_fading_statistics():
+    """Fast fading output should have zero mean and realistic variance."""
+    ff = FastFading(carrier_frequency=3.5)
+    samples = ff.generate_fading(5 / 3.6, duration=2.0, time_step=0.01)
+    mean = float(np.mean(samples))
+    std = float(np.std(samples))
+    assert abs(mean) < 1e-6
+    assert 8.0 <= std <= 11.0


### PR DESCRIPTION
## Summary
- remove slow plotting in rf model tests
- validate ABG and CI path loss results numerically
- check fast fading statistics without generating images
- verify antenna model outputs are deterministic when shadowing is disabled
- allow ML service tests to import the app package directly

Refactor RF model tests for speed by replacing plot generation with direct numerical validation, add deterministic antenna model checks, and enable ML service tests to import the app package

Enhancements:
- Remove slow plotting from RF model tests in favor of numeric assertions
- Allow ML service tests to import the app package directly via updated conftest

Tests:
- Validate ABG and Close-In path loss models against hand-computed references
- Check fast fading output statistics (zero mean, realistic variance) without generating plots
- Verify antenna model outputs are deterministic when shadowing is disabled