### PR TITLE
Update tests to clean plotting artifacts

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -137,3 +137,8 @@ pip install -r requirements.txt
 pytest services/nef-emulator/tests/integration \
        services/ml-service/tests/integration
 ```
+
+### Temporary Files
+Unit tests that generate plots now write all images to the pytest `tmp_path`
+fixture. The tests assert the files exist and remove them automatically so the
+repository remains clean.

--- a/5g-network-optimization/services/ml-service/tests/test_ml_components.py
+++ b/5g-network-optimization/services/ml-service/tests/test_ml_components.py
@@ -99,7 +99,7 @@ def test_feature_extraction():
     for feature in expected_features:
         assert feature in features, f"Missing expected feature: {feature}"
 
-def test_model_training_and_prediction():
+def test_model_training_and_prediction(tmp_path):
     """Training on synthetic data should achieve reasonable accuracy."""
 
     data = generate_synthetic_data(1000)
@@ -155,14 +155,16 @@ def test_model_training_and_prediction():
         plt.title('Feature Importance')
         plt.tight_layout()
         
-        os.makedirs('output', exist_ok=True)
-        plt.savefig('output/feature_importance.png')
+        out_path = tmp_path / "feature_importance.png"
+        plt.savefig(out_path)
         plt.close()
-        
-        print("Feature importance visualization saved to output/feature_importance.png")
+        assert out_path.exists()
+        out_path.unlink()
+
+        print(f"Feature importance visualization saved to {out_path}")
     
     # Visualize predictions in a 2D space
-    visualize_predictions(test_data, predictions)
+    visualize_predictions(test_data, predictions, tmp_path)
     
     # Save model
     try:
@@ -174,7 +176,7 @@ def test_model_training_and_prediction():
 
     assert accuracy > 0.7, f"Model accuracy too low: {accuracy:.2%}"
 
-def visualize_predictions(test_data, predictions):
+def visualize_predictions(test_data, predictions, tmp_path):
     """Visualize predictions in a 2D space."""
     print("\nVisualizing predictions...")
     
@@ -282,11 +284,13 @@ def visualize_predictions(test_data, predictions):
     
     plt.legend(handles=handles)
     
-    os.makedirs('output', exist_ok=True)
-    plt.savefig('output/prediction_visualization.png')
+    out_path = tmp_path / "prediction_visualization.png"
+    plt.savefig(out_path)
     plt.close()
-    
-    print("Prediction visualization saved to output/prediction_visualization.png")
+    assert out_path.exists()
+    out_path.unlink()
+
+    print(f"Prediction visualization saved to {out_path}")
 
 if __name__ == "__main__":
     print("Testing ML Components...")

--- a/5g-network-optimization/services/ml-service/tests/test_model.py
+++ b/5g-network-optimization/services/ml-service/tests/test_model.py
@@ -68,7 +68,7 @@ def generate_synthetic_data(num_samples=500):
     
     return data
 
-def test_model_training_and_prediction():
+def test_model_training_and_prediction(tmp_path):
     """Training the model should yield predictions with reasonable accuracy."""
 
     data = generate_synthetic_data(1000)
@@ -100,8 +100,10 @@ def test_model_training_and_prediction():
         plt.title('Feature Importance')
         plt.tight_layout()
 
-        os.makedirs('output', exist_ok=True)
-        plt.savefig('output/feature_importance.png')
+        out_path = tmp_path / "feature_importance.png"
+        plt.savefig(out_path)
+        assert out_path.exists()
+        out_path.unlink()
 
     assert accuracy > 0.7, f"Model accuracy too low: {accuracy:.2%}"
 

--- a/5g-network-optimization/services/ml-service/tests/test_plotter.py
+++ b/5g-network-optimization/services/ml-service/tests/test_plotter.py
@@ -34,6 +34,7 @@ def test_plot_functions_generate_png(tmp_path):
 
     cov_path = Path(plot_antenna_coverage(model, output_dir=tmp_path))
     _check_png(cov_path)
+    cov_path.unlink()
 
     movement = [
         {"latitude": 0, "longitude": 0, "connected_to": "a1"},
@@ -42,3 +43,4 @@ def test_plot_functions_generate_png(tmp_path):
     ]
     traj_path = Path(plot_movement_trajectory(movement, output_dir=tmp_path))
     _check_png(traj_path)
+    traj_path.unlink()


### PR DESCRIPTION
## Summary
- save plotting outputs under pytest tmp_path
- verify that plot PNGs exist and remove them
- document cleanup of temporary files


Use pytest tmp_path in plot-generating tests to save images, verify their existence, and remove them automatically, and document this cleanup in the README.

Documentation:
- Document temporary file handling and automatic cleanup for plot outputs in the README.

Tests:
- Configure model and component tests to save plots to pytest tmp_path, assert PNG files exist, and unlink them.
- Add cleanup of generated PNGs in plotter tests following existence checks.