### PR TITLE
Add path endpoint tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/conftest.py
+++ b/5g-network-optimization/services/ml-service/tests/conftest.py
@@ -6,8 +6,7 @@ import pytest
 # Ensure the service package can be imported as ``app`` before test collection.
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SERVICE_ROOT))
-# Remove potential alias from other test suites
-sys.modules.pop("app", None)
+# No cleanup here to avoid interfering with other test suites
 
 
 def load_create_app():
@@ -18,6 +17,10 @@ def load_create_app():
     ``app``, we temporarily register the loaded module under that name and
     clean it up afterwards.
     """
+
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
 
     spec = importlib.util.spec_from_file_location(
         "app",

--- a/5g-network-optimization/services/ml-service/tests/test_metrics.py
+++ b/5g-network-optimization/services/ml-service/tests/test_metrics.py
@@ -1,4 +1,9 @@
 from flask import Flask
+import sys
+
+for name in list(sys.modules.keys()):
+    if name == "app" or name.startswith("app."):
+        del sys.modules[name]
 
 from app.monitoring import metrics
 from app.monitoring.metrics import MetricsMiddleware, track_prediction, track_training

--- a/5g-network-optimization/services/ml-service/tests/test_model_init.py
+++ b/5g-network-optimization/services/ml-service/tests/test_model_init.py
@@ -12,6 +12,9 @@ spec = importlib.util.spec_from_file_location(
     submodule_search_locations=[str(SERVICE_ROOT / "app")],
 )
 app_module = importlib.util.module_from_spec(spec)
+for name in list(sys.modules.keys()):
+    if name == "app" or name.startswith("app."):
+        del sys.modules[name]
 sys.modules["app"] = app_module
 sys.modules.setdefault(
     "seaborn",
@@ -55,4 +58,11 @@ def test_initialize_model_trains_and_loads(tmp_path, monkeypatch):
     loaded = initialize_model(str(model_path))
     assert call_count["train"] == 1
     assert isinstance(loaded.model, DummyModel)
+
+
+def teardown_module(module):
+    """Remove dynamically loaded ``app`` modules after tests."""
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
 

--- a/5g-network-optimization/services/nef-emulator/tests/api/test_cell_gnb_endpoints.py
+++ b/5g-network-optimization/services/nef-emulator/tests/api/test_cell_gnb_endpoints.py
@@ -41,6 +41,9 @@ def _setup_client(monkeypatch, user=None):
 
     class gNB(BaseModel):
         gNB_id: str
+        name: str | None = None
+        description: str | None = None
+        location: str | None = None
         id: int | None = None
         owner_id: int | None = None
 
@@ -159,8 +162,12 @@ def test_update_gnb_as_owner(monkeypatch):
 
     # Simulate successful update
     def fake_update(db, db_obj, obj_in):
-        db_obj.name = obj_in["name"]
-        return db_obj
+        if isinstance(obj_in, dict):
+            name = obj_in["name"]
+        else:
+            name = obj_in.name
+        db_obj.name = name
+        return {"id": db_obj.id, "gNB_id": db_obj.gNB_id, "owner_id": db_obj.owner_id, "name": db_obj.name}
     crud.gnb.update = fake_update
 
     resp = client.put("/api/v1/gNBs/AAAAAA", json={"gNB_id": "AAAAAA", "name": "new_name"})
@@ -177,8 +184,12 @@ def test_update_gnb_as_superuser(monkeypatch):
 
     # Simulate successful update
     def fake_update(db, db_obj, obj_in):
-        db_obj.name = obj_in["name"]
-        return db_obj
+        if isinstance(obj_in, dict):
+            name = obj_in["name"]
+        else:
+            name = obj_in.name
+        db_obj.name = name
+        return {"id": db_obj.id, "gNB_id": db_obj.gNB_id, "owner_id": db_obj.owner_id, "name": db_obj.name}
     crud.gnb.update = fake_update
 
     resp = client.put("/api/v1/gNBs/AAAAAA", json={"gNB_id": "AAAAAA", "name": "superuser_update"})

--- a/5g-network-optimization/services/nef-emulator/tests/api/test_login_endpoints.py
+++ b/5g-network-optimization/services/nef-emulator/tests/api/test_login_endpoints.py
@@ -47,6 +47,11 @@ PROJECT_ROOT = Path(__file__).resolve().parents[4]
 load_dotenv(PROJECT_ROOT / ".env")
 os.environ.setdefault("USE_PUBLIC_KEY_VERIFICATION", "false")
 
+# Remove any previously loaded ``app`` modules to avoid cross-test interference
+for name in list(sys.modules.keys()):
+    if name == "app" or name.startswith("app."):
+        del sys.modules[name]
+
 # Dynamically load the ``app`` package so the real routers are available
 BACKEND_ROOT = PROJECT_ROOT / "services" / "nef-emulator" / "backend"
 APP_ROOT = BACKEND_ROOT / "app"
@@ -207,3 +212,10 @@ def test_reset_password_inactive_user(monkeypatch):
     response = client.post("/api/v1/reset-password/", json={"token": "tok", "new_password": "pass"})
     assert response.status_code == 400
     assert response.json()["detail"] == "Inactive user"
+
+
+def teardown_module(module):
+    """Clean up dynamically loaded ``app`` modules after tests."""
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]

--- a/5g-network-optimization/services/nef-emulator/tests/api/test_paths_endpoints.py
+++ b/5g-network-optimization/services/nef-emulator/tests/api/test_paths_endpoints.py
@@ -1,0 +1,182 @@
+import sys
+import types
+from types import SimpleNamespace
+from pathlib import Path as PathLib
+import importlib.util
+
+try:
+    import sqlalchemy
+except ImportError:
+    sqlalchemy = types.ModuleType("sqlalchemy")
+    sys.modules["sqlalchemy"] = sqlalchemy
+    sqlalchemy.orm = types.ModuleType("sqlalchemy.orm")
+    sqlalchemy.orm.Session = object
+    sys.modules["sqlalchemy.orm"] = sqlalchemy.orm
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from typing import List, Optional
+
+
+def _setup_client(monkeypatch, user=None):
+    if user is None:
+        user = SimpleNamespace(id=1, is_superuser=True)
+
+    def fake_get_db():
+        yield None
+
+    app_pkg = types.ModuleType("app")
+    app_pkg.__path__ = []
+    crud_mod = types.ModuleType("app.crud")
+    crud_mod.path = SimpleNamespace()
+    crud_mod.points = SimpleNamespace()
+    crud_mod.user = SimpleNamespace(is_superuser=lambda u: u.is_superuser)
+
+    models_mod = types.ModuleType("app.models")
+
+    class User(BaseModel):
+        id: int = 1
+        is_superuser: bool = False
+
+    models_mod.User = User
+
+    schemas_mod = types.ModuleType("app.schemas")
+
+    class Point(BaseModel):
+        latitude: float
+        longitude: float
+
+    class PathBase(BaseModel):
+        description: Optional[str] = None
+        start_point: Optional[Point] = None
+        end_point: Optional[Point] = None
+        color: Optional[str] = None
+
+    class PathCreate(PathBase):
+        points: Optional[List[Point]] = None
+
+    class PathUpdate(PathBase):
+        points: Optional[List[Point]] = None
+
+    class PathInDBBase(PathBase):
+        id: int
+
+        class Config:
+            orm_mode = True
+
+    class Paths(PathInDBBase):
+        pass
+
+    class Path(PathInDBBase):
+        points: Optional[List[Point]] = None
+
+    for name_, obj in locals().items():
+        if name_ in {"Point", "PathBase", "PathCreate", "PathUpdate", "PathInDBBase", "Paths", "Path"}:
+            setattr(schemas_mod, name_, obj)
+
+    api_pkg = types.ModuleType("app.api")
+    deps_mod = types.ModuleType("app.api.deps")
+    deps_mod.get_db = fake_get_db
+    deps_mod.get_current_active_user = lambda: user
+    api_pkg.deps = deps_mod
+    api_v1_pkg = types.ModuleType("app.api.api_v1")
+    endpoints_pkg = types.ModuleType("app.api.api_v1.endpoints")
+    api_v1_pkg.endpoints = endpoints_pkg
+    api_pkg.api_v1 = api_v1_pkg
+
+    app_pkg.crud = crud_mod
+    app_pkg.api = api_pkg
+    app_pkg.models = models_mod
+    app_pkg.schemas = schemas_mod
+
+    monkeypatch.setitem(sys.modules, "app", app_pkg)
+    monkeypatch.setitem(sys.modules, "app.crud", crud_mod)
+    monkeypatch.setitem(sys.modules, "app.api", api_pkg)
+    monkeypatch.setitem(sys.modules, "app.api.deps", deps_mod)
+    monkeypatch.setitem(sys.modules, "app.api.api_v1", api_v1_pkg)
+    monkeypatch.setitem(sys.modules, "app.api.api_v1.endpoints", endpoints_pkg)
+    monkeypatch.setitem(sys.modules, "app.models", models_mod)
+    monkeypatch.setitem(sys.modules, "app.schemas", schemas_mod)
+
+    endpoints_dir = PathLib(__file__).resolve().parents[2] / "backend" / "app" / "app" / "api" / "api_v1" / "endpoints"
+    spec = importlib.util.spec_from_file_location("paths", endpoints_dir / "paths.py")
+    paths_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(paths_mod)
+
+    app_instance = FastAPI()
+    app_instance.include_router(paths_mod.router, prefix="/api/v1/paths")
+
+    client = TestClient(app_instance)
+    return client, crud_mod, paths_mod
+
+
+def _dummy_path(owner_id=1):
+    return SimpleNamespace(
+        id=1,
+        description="p1",
+        start_lat=0.0,
+        start_long=0.0,
+        end_lat=1.0,
+        end_long=1.0,
+        color="blue",
+        owner_id=owner_id,
+    )
+
+
+def test_get_random_point(monkeypatch):
+    client, crud, paths_mod = _setup_client(monkeypatch)
+    points = [SimpleNamespace(latitude=0.0, longitude=0.0), SimpleNamespace(latitude=1.0, longitude=1.0)]
+    monkeypatch.setattr(crud.points, "get_points", lambda db, path_id: points, raising=False)
+    monkeypatch.setattr(paths_mod.random, "randrange", lambda a, b: 1)
+    pt = paths_mod.get_random_point(db=None, path_id=1)
+    assert pt == {"latitude": 1.0, "longitude": 1.0}
+
+
+def test_read_paths(monkeypatch):
+    client, crud, _ = _setup_client(monkeypatch)
+    monkeypatch.setattr(crud.path, "get_multi", lambda db, skip=0, limit=100: [_dummy_path()], raising=False)
+    resp = client.get("/api/v1/paths")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["description"] == "p1"
+    assert data[0]["start_point"]["latitude"] == 0.0
+
+
+def test_create_path(monkeypatch):
+    client, crud, _ = _setup_client(monkeypatch)
+    monkeypatch.setattr(crud.path, "get_description", lambda db, description: None, raising=False)
+    monkeypatch.setattr(crud.path, "create_with_owner", lambda db, obj_in, owner_id: _dummy_path(), raising=False)
+    monkeypatch.setattr(crud.points, "create", lambda db, obj_in, path_id: None, raising=False)
+    payload = {"description": "p1", "start_point": {"latitude": 0.0, "longitude": 0.0}, "end_point": {"latitude": 1.0, "longitude": 1.0}, "color": "blue", "points": []}
+    resp = client.post("/api/v1/paths", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "p1"
+
+
+def test_update_path(monkeypatch):
+    client, crud, _ = _setup_client(monkeypatch)
+    original = _dummy_path()
+    monkeypatch.setattr(crud.path, "get", lambda db, id: original, raising=False)
+
+    def fake_update(db, db_obj, obj_in):
+        if isinstance(obj_in, dict):
+            db_obj.description = obj_in["description"]
+        else:
+            db_obj.description = obj_in.description
+        return db_obj
+    monkeypatch.setattr(crud.path, "update", fake_update, raising=False)
+
+    payload = {"description": "new", "start_point": {"latitude": 0.0, "longitude": 0.0}, "end_point": {"latitude": 1.0, "longitude": 1.0}, "color": "blue", "points": []}
+    resp = client.put("/api/v1/paths/1", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["description"] == "new"
+
+
+def test_read_path(monkeypatch):
+    client, crud, _ = _setup_client(monkeypatch)
+    monkeypatch.setattr(crud.path, "get", lambda db, id: _dummy_path(), raising=False)
+    monkeypatch.setattr(crud.points, "get_points", lambda db, path_id: [SimpleNamespace(latitude=0.0, longitude=0.0)], raising=False)
+    resp = client.get("/api/v1/paths/1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["points"][0]["latitude"] == 0.0


### PR DESCRIPTION
## Summary
- create `test_paths_endpoints.py` with API endpoint tests for paths
- reset `app` modules between tests to avoid cross-suite conflicts
- cleanup modules in login test
- ensure ml-service tests load their own app modules
- adjust gNB tests to work with Pydantic models

## Testing
- `pytest -q services/nef-emulator/tests/api/test_paths_endpoints.py`
- `pytest -q` *(fails: 1 failed, 107 passed, 2 skipped, 25 warnings, 3 errors)*

Improve test isolation by cleaning up dynamically loaded application modules across suites and expand API endpoint coverage by adding path endpoint tests and updating gNB tests for Pydantic compatibility

Tests:
- Add comprehensive path endpoint tests covering list, read, create, update, and random-point operations
- Enhance gNB endpoint tests with optional name, description, and location fields and adjust fake_update for dict and Pydantic inputs
- Introduce cleanup of dynamically loaded app modules in login and ml-service tests to prevent cross-test interference
- Move app module teardown into ml-service fixture and individual test modules for proper isolation