### PR TITLE
Add ML service entrypoint tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_entrypoints.py
+++ b/5g-network-optimization/services/ml-service/tests/test_entrypoints.py
@@ -1,0 +1,78 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+APP_ENTRY = SERVICE_ROOT / "app.py"
+COLLECT_ENTRY = SERVICE_ROOT / "collect_training_data.py"
+
+
+def _load_app_package():
+    """Load the ``app`` package while stubbing optional deps."""
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        "app",
+        SERVICE_ROOT / "app" / "__init__.py",
+        submodule_search_locations=[str(SERVICE_ROOT / "app")],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["app"] = module
+    # stub seaborn if not installed
+    sys.modules.setdefault(
+        "seaborn",
+        importlib.util.module_from_spec(importlib.util.spec_from_loader("seaborn", loader=None)),
+    )
+    spec.loader.exec_module(module)
+    return module
+
+
+def _unload_app_package():
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_app_entrypoint_calls_create_app(monkeypatch):
+    app_pkg = _load_app_package()
+    mock_create = MagicMock(return_value="instance")
+    monkeypatch.setattr(app_pkg, "create_app", mock_create)
+    try:
+        module = _load_module(APP_ENTRY, "app_entry")
+        assert module.app == "instance"
+        mock_create.assert_called_once()
+    finally:
+        _unload_app_package()
+
+
+def test_collect_training_data_main_success(monkeypatch):
+    module = _load_module(COLLECT_ENTRY, "collect_script")
+    collector = MagicMock()
+    collector.login.return_value = True
+    collector.get_ue_movement_state.return_value = {"ue": {"Cell_id": "A", "latitude": 0, "longitude": 0, "speed": 1}}
+    collector.collect_training_data.return_value = [{"dummy": 1}]
+    monkeypatch.setattr(module, "NEFDataCollector", lambda **kw: collector)
+    response = MagicMock(status_code=200, json=lambda: {"metrics": {}})
+    monkeypatch.setitem(sys.modules, "requests", MagicMock(post=MagicMock(return_value=response)))
+    monkeypatch.setattr(sys, "argv", ["collect_training_data", "--train"])
+    assert module.main() == 0
+    collector.login.assert_called_once()
+    collector.collect_training_data.assert_called_once()
+
+
+def test_collect_training_data_main_failure(monkeypatch):
+    module = _load_module(COLLECT_ENTRY, "collect_script_fail")
+    collector = MagicMock()
+    collector.login.return_value = False
+    monkeypatch.setattr(module, "NEFDataCollector", lambda **kw: collector)
+    monkeypatch.setattr(sys, "argv", ["collect_training_data"])
+    assert module.main() == 1


### PR DESCRIPTION
## Summary
- add tests ensuring ML service entrypoints behave correctly
  - verify `create_app()` runs when `app.py` is imported
  - cover success and failure paths of `collect_training_data.main`

## Testing
- `pytest 5g-network-optimization/services/ml-service/tests/test_entrypoints.py -q`
- `pytest -q`
