### PR TITLE
Replace live NEF mobility tests with TestClient

### DIFF
--- a/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_api.py
+++ b/5g-network-optimization/services/nef-emulator/tests/integration/test_mobility_api.py
@@ -1,82 +1,92 @@
-"""Integration tests for the mobility patterns API."""
-import requests
-import json
-import matplotlib.pyplot as plt
-import numpy as np
+from types import ModuleType, SimpleNamespace
+import importlib.util
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 
 
-def _nef_running() -> bool:
-    try:
-        r = requests.get("http://localhost:8080/docs", timeout=2)
-        return r.status_code == 200
-    except requests.RequestException:
-        return False
+def _create_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Return TestClient for the mobility patterns router."""
+    backend_root = Path(__file__).resolve().parents[2] / "backend" / "app"
+    monkeypatch.syspath_prepend(str(backend_root))
 
-def test_generate_linear_pattern():
-    """Test generating a linear mobility pattern through the API."""
-    if not _nef_running():
-        pytest.skip("NEF emulator is not running")
-    url = "http://localhost:8080/api/v1/mobility-patterns/generate"
-    
-    # Login to get token
-    login_url = "http://localhost:8080/api/v1/login/access-token"
-    login_data = {
-        "username": "admin",  # Use your credentials
-        "password": "admin"   # Use your credentials
-    }
-    login_response = requests.post(login_url, data=login_data)
-    if login_response.status_code != 200:
-        print(f"Login failed: {login_response.status_code} - {login_response.text}")
-        return False
-    
-    token = login_response.json()["access_token"]
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
-    }
-    
-    # API request
+    for name in list(sys.modules.keys()):
+        if name == "app" or name.startswith("app."):
+            del sys.modules[name]
+
+    # Load the real mobility adapter module
+    spec_adapter = importlib.util.spec_from_file_location(
+        "app.tools.mobility.adapter",
+        backend_root / "app" / "tools" / "mobility" / "adapter.py",
+    )
+    adapter_mod = importlib.util.module_from_spec(spec_adapter)
+    spec_adapter.loader.exec_module(adapter_mod)
+
+    mobility_pkg = ModuleType("app.tools.mobility")
+    mobility_pkg.adapter = adapter_mod
+    tools_pkg = ModuleType("app.tools")
+    tools_pkg.mobility = mobility_pkg
+
+    deps_mod = ModuleType("app.api.deps")
+    deps_mod.get_current_active_user = lambda: SimpleNamespace(id=1)
+    api_pkg = ModuleType("app.api")
+    api_pkg.deps = deps_mod
+
+    user_mod = ModuleType("app.models.user")
+    user_mod.User = SimpleNamespace
+    models_pkg = ModuleType("app.models")
+    models_pkg.user = user_mod
+
+    app_pkg = ModuleType("app")
+    app_pkg.api = api_pkg
+    app_pkg.tools = tools_pkg
+    app_pkg.models = models_pkg
+
+    for name, mod in {
+        "app": app_pkg,
+        "app.api": api_pkg,
+        "app.api.deps": deps_mod,
+        "app.tools": tools_pkg,
+        "app.tools.mobility": mobility_pkg,
+        "app.tools.mobility.adapter": adapter_mod,
+        "app.models": models_pkg,
+        "app.models.user": user_mod,
+    }.items():
+        sys.modules[name] = mod
+
+    spec_router = importlib.util.spec_from_file_location(
+        "patterns",
+        backend_root / "app" / "api" / "api_v1" / "endpoints" / "mobility" / "patterns.py",
+    )
+    patterns = importlib.util.module_from_spec(spec_router)
+    spec_router.loader.exec_module(patterns)
+
+    app = FastAPI()
+    app.include_router(patterns.router, prefix="/api/v1/mobility-patterns")
+    app.dependency_overrides[deps_mod.get_current_active_user] = lambda: SimpleNamespace(id=1)
+    return TestClient(app)
+
+
+def test_generate_linear_pattern(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_client(monkeypatch)
     payload = {
         "model_type": "linear",
-        "ue_id": "test_ue_1",
-        "duration": 300,
+        "ue_id": "test",
+        "duration": 5,
         "time_step": 1.0,
         "parameters": {
             "start_position": [0, 0, 0],
-            "end_position": [1000, 500, 0],
-            "speed": 5.0
-        }
+            "end_position": [10, 0, 0],
+            "speed": 1.0,
+        },
     }
-    
-    # Make the request
-    response = requests.post(url, json=payload, headers=headers)
-    
-    if response.status_code == 200:
-        points = response.json()
-        print(f"Generated {len(points)} points")
-        
-        # Plot the points
-        latitudes = [point['latitude'] for point in points]
-        longitudes = [point['longitude'] for point in points]
-        
-        plt.figure(figsize=(10, 6))
-        plt.plot(latitudes, longitudes, 'b-', linewidth=2)
-        plt.plot(latitudes[0], longitudes[0], 'go', markersize=10)  # Start point
-        plt.plot(latitudes[-1], longitudes[-1], 'ro', markersize=10)  # End point
-        
-        plt.xlabel('Latitude')
-        plt.ylabel('Longitude')
-        plt.title('Generated Linear Mobility Pattern')
-        plt.grid(True)
-        
-        plt.savefig('linear_api_pattern.png')
-        print("Plot saved as linear_api_pattern.png")
-        return True
-    else:
-        print(f"Error: {response.status_code}, {response.text}")
-        return False
-
-if __name__ == "__main__":
-    success = test_generate_linear_pattern()
-    print(f"Test {'succeeded' if success else 'failed'}")
+    resp = client.post("/api/v1/mobility-patterns/generate", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list) and data
+    assert data[0]["latitude"] == 0
+    # With duration 5s and speed 1 m/s, final position should be ~5 meters away.
+    assert data[-1]["latitude"] == pytest.approx(5, abs=0.1)


### PR DESCRIPTION
## Summary
- replace mobility integration tests that required a running NEF service
- use FastAPI `TestClient` and module stubs so tests run fully offline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0b220ab88333bbec262979b09c5e