### PR TITLE
Reduce synthetic dataset size for faster ML test

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_ml_components.py
+++ b/5g-network-optimization/services/ml-service/tests/test_ml_components.py
@@ -102,7 +102,7 @@ def test_feature_extraction():
 def test_model_training_and_prediction(tmp_path):
     """Training on synthetic data should achieve reasonable accuracy."""
 
-    data = generate_synthetic_data(1000)
+    data = generate_synthetic_data(100)
 
     train_data, test_data = train_test_split(data, test_size=0.2, random_state=42)
 
@@ -131,6 +131,7 @@ def test_model_training_and_prediction(tmp_path):
             correct += 1
 
     accuracy = correct / len(test_data)
+    print(f"Accuracy: {accuracy:.2%}")
     
     # Visualize feature importance if available
     feature_importance = metrics.get('feature_importance', {})


### PR DESCRIPTION
## Summary
- shrink synthetic dataset in `test_ml_components.py`
- print training accuracy so it's visible in the test logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d28930cd08333aced388014f2f449