### PR TITLE
Enable offline ML handover test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,5 @@ email-validator==2.2.0
 python-jose==3.3.0
 passlib==1.7.4
 python-multipart==0.0.20
+pyOpenSSL==22.1.0
+prometheus_client==0.20.0


### PR DESCRIPTION
## Summary
- remove module skip from `test_handover_e2e`
- replace heavy ML service imports with lightweight dummy classes
- load FastAPI router directly and exercise `/ml/handover` route
- install missing libraries for tests via requirements

## Testing
- `pytest -q services/nef-emulator/tests/integration/test_handover_e2e.py`
- `pytest -q`

Enable offline execution of the ML handover integration test by introducing dummy classes for ML components, loading the FastAPI handover router directly in tests, and adding missing test dependencies.

New Features:
- Enable offline ML handover integration test by mock-simulating ML service components

Enhancements:
- Replace heavy ML service imports with DummyAntenna and DummySelector classes
- Load the ML handover FastAPI router directly into a TestClient for end-to-end testing
- Mock network state_manager and antenna_selector modules dynamically for isolated testing

Build:
- Add pyOpenSSL and prometheus_client to requirements.txt for testing

Tests:
- Activate and adapt test_handover_e2e to run without full ML service context