### PR TITLE
Add system dependency install script

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -123,9 +123,9 @@ docker push <registry>/ml-service:latest
 ```
 
 ## Testing
-First install the dependencies using the repository root `requirements.txt`. Some packages (e.g. `tables`) require system libraries such as `libhdf5-dev` on Ubuntu.
+First install the required system libraries, then the Python packages. Use the helper script `scripts/install_system_deps.sh` from the repository root:
 ```bash
-sudo apt-get update && sudo apt-get install -y libhdf5-dev
+./scripts/install_system_deps.sh
 pip install -r requirements.txt
 ```
 

--- a/scripts/install_system_deps.sh
+++ b/scripts/install_system_deps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y libhdf5-dev libffi-dev libcairo2 libpango-1.0-0 libjpeg-dev
+


### PR DESCRIPTION
## Summary
- add `install_system_deps.sh` script for apt packages
- update 5g README to run the new script before installing Python requirements

## Testing
- `pytest -q`
