### PR TITLE
Fix pydantic validator reuse

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/core/config.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/core/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     # ----- CORS -----
     BACKEND_CORS_ORIGINS: List[str] = []
 
-    @validator("BACKEND_CORS_ORIGINS", pre=True)
+    @validator("BACKEND_CORS_ORIGINS", pre=True, allow_reuse=True)
     def assemble_cors_origins(
         cls, v: Union[str, List[str]]
     ) -> Union[List[str], str]:
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "My Awesome Project"
     SENTRY_DSN: Optional[AnyHttpUrl] = None
 
-    @validator("SENTRY_DSN", pre=True)
+    @validator("SENTRY_DSN", pre=True, allow_reuse=True)
     def sentry_dsn_can_be_blank(cls, v: str) -> Optional[str]:
         if not v:
             return None
@@ -52,7 +52,7 @@ class Settings(BaseSettings):
     POSTGRES_DB: str
     SQLALCHEMY_DATABASE_URI: Optional[PostgresDsn] = None
 
-    @validator("SQLALCHEMY_DATABASE_URI", pre=True)
+    @validator("SQLALCHEMY_DATABASE_URI", pre=True, allow_reuse=True)
     def assemble_db_connection(
         cls, v: Optional[str], values: Dict[str, Any]
     ) -> Any:
@@ -83,7 +83,7 @@ class Settings(BaseSettings):
     EMAILS_FROM_EMAIL: Optional[EmailStr] = None
     EMAILS_FROM_NAME: Optional[str] = None
 
-    @validator("EMAILS_FROM_NAME")
+    @validator("EMAILS_FROM_NAME", allow_reuse=True)
     def get_project_name(
         cls, v: Optional[str], values: Dict[str, Any]
     ) -> str:
@@ -93,7 +93,7 @@ class Settings(BaseSettings):
     EMAIL_TEMPLATES_DIR: str = "/app/app/email-templates/build"
     EMAILS_ENABLED: bool = False
 
-    @validator("EMAILS_ENABLED", pre=True)
+    @validator("EMAILS_ENABLED", pre=True, allow_reuse=True)
     def get_emails_enabled(cls, v: bool, values: Dict[str, Any]) -> bool:
         return bool(
             values.get("SMTP_HOST")


### PR DESCRIPTION
## Summary
- allow pydantic validators to be reused when reloading the `Settings` module
- reload `Settings` in tests to confirm validators are not duplicated

## Testing
- `pytest -q 5g-network-optimization/services/nef-emulator/tests/test_config.py`
- `pytest -q`

Allow Pydantic validators to be reused when reloading the Settings module and add tests to confirm validators aren’t duplicated on consecutive imports.

Bug Fixes:
- Prevent duplicate validator registration errors when reloading the Settings module by enabling validator reuse.

Enhancements:
- Add `allow_reuse=True` to all Pydantic `@validator` decorators in the Settings class to enable validator reuse.

Tests:
- Update `_load_config` helper to use `importlib.reload` and add a test to verify identical Settings outputs across multiple imports.