### PR TITLE
Fix CRUD mongo import for NEF emulator tests

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/crud/__init__.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/crud/__init__.py
@@ -4,6 +4,7 @@ from .crud_gNB import gnb
 from .crud_Cell import cell
 from .crud_UE import ue
 from .crud_monitoringevent import monitoring
+from . import crud_mongo
 
 # For a new basic set of CRUD operations you could just do
 

--- a/5g-network-optimization/services/nef-emulator/tests/conftest.py
+++ b/5g-network-optimization/services/nef-emulator/tests/conftest.py
@@ -32,8 +32,3 @@ app_pkg.network = network_pkg
 sys.modules.setdefault("app", app_pkg)
 sys.modules.setdefault("app.network", network_pkg)
 sys.modules.setdefault("app.network.state_manager", state_mgr)
-
-# Provide a minimal stub for optional database module used in tools
-crud_stub = types.ModuleType("crud")
-crud_stub.crud_mongo = object()
-sys.modules.setdefault("app.crud", crud_stub)


### PR DESCRIPTION
## Summary
- configure test harness to expose NEF backend as the `app` package
- load `app.core` modules from the real application
- treat `crud_mongo` as a module import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e99ddc4388333a5accb78d0be80ca