### PR TITLE
Improve testing docs and setup script

### DIFF
--- a/5g-network-optimization/README.md
+++ b/5g-network-optimization/README.md
@@ -132,10 +132,11 @@ docker push <registry>/ml-service:latest
 ```
 
 ## Testing
-First install the required system libraries, then the Python packages. Use the helper script `scripts/install_system_deps.sh` from the repository root:
+First install the required system libraries, then the Python packages. Use the helper script `scripts/install_system_deps.sh` from the repository root and run the test suite:
 ```bash
 ./scripts/install_system_deps.sh
 pip install -r requirements.txt
+pytest
 ```
 
 ### Extended Integration Tests

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,3 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install Python dependencies for local development and CI
-pip install -r requirements.txt
+set -euo pipefail
+
+python -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- document running pytest after installing dependencies
- harden install_deps script with strict bash options

Harden the dependency installation script and improve testing setup documentation

Enhancements:
- Use env bash shebang and enable strict bash options in install_deps.sh
- Invoke pip via python -m pip in install_deps.sh

Documentation:
- Update README testing section to use install_system_deps script and run pytest

Tests:
- Add instruction to execute pytest as part of the testing setup