### PR TITLE
Remove unused email helper

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/utils.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/utils.py
@@ -33,19 +33,6 @@ def send_email(
     logging.info(f"send email result: {response}")
 
 
-def send_test_email(email_to: str) -> None:
-    project_name = settings.PROJECT_NAME
-    subject = f"{project_name} - Test email"
-    with open(Path(settings.EMAIL_TEMPLATES_DIR) / "test_email.html") as f:
-        template_str = f.read()
-    send_email(
-        email_to=email_to,
-        subject_template=subject,
-        html_template=template_str,
-        environment={"project_name": settings.PROJECT_NAME, "email": email_to},
-    )
-
-
 def send_reset_password_email(email_to: str, email: str, token: str) -> None:
     project_name = settings.PROJECT_NAME
     subject = f"{project_name} - Password recovery for user {email}"


### PR DESCRIPTION
## Summary
- delete `send_test_email` function from utils since nothing uses it

Chores:
- Delete the send_test_email function and associated template reading logic