### PR TITLE
Remove redundant pytest config

### DIFF
--- a/5g-network-optimization/pytest.ini
+++ b/5g-network-optimization/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-testpaths = services/nef-emulator/tests services/ml-service/tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-testpaths = 5g-network-optimization/services/nef-emulator/tests 5g-network-optimization/services/ml-service/tests
+testpaths =
+    5g-network-optimization/services/nef-emulator/tests
+    5g-network-optimization/services/ml-service/tests


### PR DESCRIPTION
## Summary
- delete duplicated pytest config in `5g-network-optimization`
- keep root `pytest.ini` and specify test directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863051626f883338fc4d215dfeb9e4b