### PR TITLE
Clean up pytest configs

### DIFF
--- a/5g-network-optimization/pytest.ini
+++ b/5g-network-optimization/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-testpaths = services/nef-emulator/tests services/ml-service/tests


### PR DESCRIPTION
## Summary
- remove nested pytest.ini
- keep root pytest.ini pointing at both test suites

## Testing
- `pytest --collect-only -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686305a0264c8333b3b4aebc7dae2b7c

## Summary by Sourcery

Clean up Pytest configuration by removing the nested pytest.ini and consolidating test discovery in the root pytest.ini

Enhancements:
- Remove redundant pytest.ini in the 5g-network-optimization directory
- Ensure the root pytest.ini covers both test suites for collection

Tests:
- Validate configuration via `pytest --collect-only` and full test runs