### PR TITLE
Remove main guards from tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/test_ml_components.py
+++ b/5g-network-optimization/services/ml-service/tests/test_ml_components.py
@@ -290,17 +290,3 @@ def visualize_predictions(test_data, predictions, tmp_path):
     plt.close()
     assert out_path.exists()
     out_path.unlink()
-
-    print(f"Prediction visualization saved to {out_path}")
-
-if __name__ == "__main__":
-    print("Testing ML Components...")
-    
-    results = []
-    results.append(("Feature Extraction", test_feature_extraction()))
-    results.append(("Model Training and Prediction", test_model_training_and_prediction()))
-    
-    print("\nSummary of Results:")
-    for test_name, result in results:
-        status = "✓ PASS" if result else "✗ FAIL"
-        print(f"{status} - {test_name}")

--- a/5g-network-optimization/services/ml-service/tests/test_model.py
+++ b/5g-network-optimization/services/ml-service/tests/test_model.py
@@ -107,5 +107,3 @@ def test_model_training_and_prediction(tmp_path):
 
     assert accuracy > 0.7, f"Model accuracy too low: {accuracy:.2%}"
 
-if __name__ == "__main__":  # pragma: no cover
-    test_model_training_and_prediction()

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/tests_pre_start.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/tests_pre_start.py
@@ -33,5 +33,3 @@ def main() -> None:
     logger.info("Service finished initializing")
 
 
-if __name__ == "__main__":
-    main()

--- a/5g-network-optimization/services/nef-emulator/backend/app/tests/mobility_test.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/tests/mobility_test.py
@@ -105,6 +105,3 @@ def test_linear_mobility():
     
     return True
 
-if __name__ == "__main__":
-    test_linear_mobility()
-    print("Test completed")

--- a/5g-network-optimization/services/nef-emulator/backend/app/tests/test_nef_adapter.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/tests/test_nef_adapter.py
@@ -74,8 +74,3 @@ def test_nef_adapter():
     
     return True
 
-if __name__ == "__main__":
-    if test_nef_adapter():
-        print("NEF adapter test successful!")
-    else:
-        print("NEF adapter test failed.")

--- a/5g-network-optimization/services/nef-emulator/tests/rf_models/test_antenna_models.py
+++ b/5g-network-optimization/services/nef-emulator/tests/rf_models/test_antenna_models.py
@@ -90,5 +90,3 @@ def test_deterministic_outputs_without_shadowing(ue_position):
     assert round(rs_expected, 10) == -88.5401390252
     assert round(sinr_expected, 10) == -11.1543710146
 
-if __name__ == "__main__":
-    sys.exit(pytest.main([__file__]))

--- a/5g-network-optimization/services/nef-emulator/tests/test_adapter.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_adapter.py
@@ -32,9 +32,3 @@ def test_adapter():
     assert latitudes[-1] == pytest.approx(100, abs=2)
     assert longitudes[-1] == pytest.approx(50, abs=2)
 
-if __name__ == "__main__":
-    success = test_adapter()
-    if success:
-        print("Adapter test successful!")
-    else:
-        print("Adapter test failed.")

--- a/5g-network-optimization/services/nef-emulator/tests/test_imports.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_imports.py
@@ -21,5 +21,3 @@ def test_imports():
     assert MobilityPatternAdapter
 
 
-if __name__ == "__main__":  # pragma: no cover
-    test_imports()

--- a/5g-network-optimization/services/nef-emulator/tests/test_mobility_models.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_mobility_models.py
@@ -243,6 +243,3 @@ def test_urban_grid_mobility():
             changed = True
     assert changed, "Direction never changed at intersections despite probability=1"
 
-if __name__ == "__main__":
-    import pytest
-    sys.exit(pytest.main([__file__]))

--- a/5g-network-optimization/services/nef-emulator/tests/test_mock_api.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_mock_api.py
@@ -59,9 +59,3 @@ def test_mock_api():
     
     assert points is not None and len(points) > 0
 
-if __name__ == "__main__":
-    success = test_mock_api()
-    if success:
-        print("Mock API test successful!")
-    else:
-        print("Mock API test failed.")

--- a/5g-network-optimization/services/nef-emulator/tests/test_state_manager.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_state_manager.py
@@ -107,5 +107,3 @@ def test_get_position_at_time_multiseg(nsm):
     assert pytest.approx(p[1]) == 5.0
     assert p[2] == 0.0
 
-if __name__ == "__main__":
-    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- prune `if __name__ == "__main__"` blocks from all tests
