### PR TITLE
Refactor NEF data collection to reuse client

### DIFF
--- a/5g-network-optimization/services/ml-service/app/data/nef_collector.py
+++ b/5g-network-optimization/services/ml-service/app/data/nef_collector.py
@@ -44,7 +44,7 @@ class NEFDataCollector:
         """Get current state of all UEs in movement."""
         try:
             state = self.client.get_ue_movement_state()
-            if state:
+            if state is not None:
                 ue_count = len(state.keys())
                 self.logger.info(f"Retrieved state for {ue_count} moving UEs")
             return state

--- a/5g-network-optimization/services/ml-service/app/data/nef_collector.py
+++ b/5g-network-optimization/services/ml-service/app/data/nef_collector.py
@@ -1,17 +1,19 @@
 """Data collection from NEF emulator for ML training."""
-import requests
 import json
-import pandas as pd
-import time
-import os
 import logging
+import os
 from datetime import datetime
+
+import time
+
+from app.clients.nef_client import NEFClient
 
 class NEFDataCollector:
     """Collect data from NEF emulator for ML training."""
     
     def __init__(self, nef_url="http://localhost:8080", username=None, password=None):
         """Initialize the data collector."""
+        self.client = NEFClient(nef_url, username=username, password=password)
         self.nef_url = nef_url
         self.username = username
         self.password = password
@@ -28,49 +30,24 @@ class NEFDataCollector:
         self.logger = logging.getLogger('NEFDataCollector')
     
     def login(self):
-        """Login to NEF emulator and get access token."""
-        if not self.username or not self.password:
-            self.logger.warning("No credentials provided, skipping authentication")
-            return False
-        
-        try:
-            login_url = f"{self.nef_url}/api/v1/login/access-token"
-            response = requests.post(
-                login_url,
-                data={
-                    "username": self.username,
-                    "password": self.password
-                }
-            )
-            
-            if response.status_code == 200:
-                self.token = response.json().get("access_token")
-                self.headers = {"Authorization": f"Bearer {self.token}"}
-                self.logger.info("Successfully logged in to NEF emulator")
-                return True
-            else:
-                self.logger.error(f"Login failed: {response.status_code} - {response.text}")
-                return False
-        
-        except Exception as e:
-            self.logger.error(f"Login error: {str(e)}")
-            return False
+        """Login to NEF emulator and store access token."""
+        success = self.client.login()
+        if success:
+            self.token = self.client.token
+            self.headers = self.client.get_headers()
+        else:
+            self.token = None
+            self.headers = {}
+        return success
     
     def get_ue_movement_state(self):
         """Get current state of all UEs in movement."""
         try:
-            state_url = f"{self.nef_url}/api/v1/ue-movement/state-ues"
-            response = requests.get(state_url, headers=self.headers)
-            
-            if response.status_code == 200:
-                state = response.json()
+            state = self.client.get_ue_movement_state()
+            if state:
                 ue_count = len(state.keys())
                 self.logger.info(f"Retrieved state for {ue_count} moving UEs")
-                return state
-            else:
-                self.logger.error(f"Failed to get UE movement state: {response.status_code} - {response.text}")
-                return {}
-        
+            return state
         except Exception as e:
             self.logger.error(f"Error getting UE movement state: {str(e)}")
             return {}

--- a/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
+++ b/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
@@ -1,8 +1,21 @@
 from unittest.mock import MagicMock, patch
 import importlib.util
 from pathlib import Path
+import sys
 
-NEF_COLLECTOR_PATH = Path(__file__).resolve().parents[2] / "app" / "data" / "nef_collector.py"
+SERVICE_ROOT = Path(__file__).resolve().parents[2]
+spec_app = importlib.util.spec_from_file_location(
+    "app", SERVICE_ROOT / "app" / "__init__.py", submodule_search_locations=[str(SERVICE_ROOT / "app")]
+)
+app_module = importlib.util.module_from_spec(spec_app)
+sys.modules["app"] = app_module
+sys.modules.setdefault(
+    "seaborn",
+    importlib.util.module_from_spec(importlib.util.spec_from_loader("seaborn", loader=None)),
+)
+spec_app.loader.exec_module(app_module)
+
+NEF_COLLECTOR_PATH = SERVICE_ROOT / "app" / "data" / "nef_collector.py"
 spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
 nef_collector = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(nef_collector)
@@ -10,30 +23,35 @@ NEFDataCollector = nef_collector.NEFDataCollector
 
 
 def test_login_success():
-    collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
-    mock_resp = MagicMock(status_code=200, json=lambda: {"access_token": "tok"})
-    with patch("requests.post", return_value=mock_resp) as mock_post:
+    mock_client = MagicMock()
+    mock_client.login.return_value = True
+    mock_client.token = "tok"
+    mock_client.get_headers.return_value = {"Authorization": "Bearer tok"}
+    with patch.object(nef_collector, "NEFClient", lambda *a, **k: mock_client):
+        collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
         assert collector.login() is True
         assert collector.token == "tok"
-        mock_post.assert_called_once()
+        mock_client.login.assert_called_once()
 
 
 def test_get_ue_movement_state():
-    collector = NEFDataCollector(nef_url="http://nef")
-    collector.headers = {"Authorization": "Bearer tok"}
-    mock_resp = MagicMock(status_code=200, json=lambda: {"ue1": {"latitude": 1, "longitude": 2}})
-    with patch("requests.get", return_value=mock_resp) as mock_get:
+    mock_client = MagicMock()
+    mock_client.get_ue_movement_state.return_value = {"ue1": {"latitude": 1, "longitude": 2}}
+    with patch.object(nef_collector, "NEFClient", lambda *a, **k: mock_client):
+        collector = NEFDataCollector(nef_url="http://nef")
         state = collector.get_ue_movement_state()
         assert state["ue1"]["latitude"] == 1
-        mock_get.assert_called_once()
+        mock_client.get_ue_movement_state.assert_called_once()
 
 
 def test_collect_training_data():
-    collector = NEFDataCollector(nef_url="http://nef")
     sample_state = {"ue1": {"latitude": 0, "longitude": 0, "speed": 1.0, "Cell_id": "A"}}
-    with patch.object(collector, "get_ue_movement_state", return_value=sample_state), \
+    mock_client = MagicMock()
+    mock_client.get_ue_movement_state.return_value = sample_state
+    with patch.object(nef_collector, "NEFClient", lambda *a, **k: mock_client), \
          patch("time.sleep"), \
          patch("time.time", side_effect=[0, 0.1, 1.1]):
+        collector = NEFDataCollector(nef_url="http://nef")
         data = collector.collect_training_data(duration=1, interval=1)
         assert len(data) == 1
         assert data[0]["ue_id"] == "ue1"

--- a/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
+++ b/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
@@ -2,8 +2,21 @@ import importlib.util
 from pathlib import Path
 import json
 from unittest.mock import MagicMock
+import sys
 
-NEF_COLLECTOR_PATH = Path(__file__).resolve().parents[1] / "app" / "data" / "nef_collector.py"
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+spec_app = importlib.util.spec_from_file_location(
+    "app", SERVICE_ROOT / "app" / "__init__.py", submodule_search_locations=[str(SERVICE_ROOT / "app")]
+)
+app_module = importlib.util.module_from_spec(spec_app)
+sys.modules["app"] = app_module
+sys.modules.setdefault(
+    "seaborn",
+    importlib.util.module_from_spec(importlib.util.spec_from_loader("seaborn", loader=None)),
+)
+spec_app.loader.exec_module(app_module)
+
+NEF_COLLECTOR_PATH = SERVICE_ROOT / "app" / "data" / "nef_collector.py"
 spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
 nef_collector = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(nef_collector)
@@ -11,9 +24,12 @@ NEFDataCollector = nef_collector.NEFDataCollector
 
 
 def test_login(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.login.return_value = True
+    mock_client.token = "tok"
+    mock_client.get_headers.return_value = {"Authorization": "Bearer tok"}
+    monkeypatch.setattr(nef_collector, "NEFClient", lambda *a, **k: mock_client)
     collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
-    mock_resp = MagicMock(status_code=200, json=lambda: {"access_token": "tok"})
-    monkeypatch.setattr(nef_collector.requests, "post", lambda *a, **k: mock_resp)
     assert collector.login() is True
     assert collector.token == "tok"
     assert collector.headers["Authorization"] == "Bearer tok"
@@ -21,9 +37,8 @@ def test_login(monkeypatch):
 
 def test_get_ue_movement_state(monkeypatch):
     collector = NEFDataCollector(nef_url="http://nef")
-    collector.headers = {"Authorization": "Bearer tok"}
-    mock_resp = MagicMock(status_code=200, json=lambda: {"ue1": {"latitude": 1}})
-    monkeypatch.setattr(nef_collector.requests, "get", lambda *a, **k: mock_resp)
+    mock_client = MagicMock(get_ue_movement_state=lambda: {"ue1": {"latitude": 1}})
+    collector.client = mock_client
     state = collector.get_ue_movement_state()
     assert state == {"ue1": {"latitude": 1}}
 
@@ -33,8 +48,8 @@ def test_collect_training_data(tmp_path, monkeypatch):
     collector.data_dir = str(tmp_path)
 
     sample_state = {"ue1": {"latitude": 0, "longitude": 0, "speed": 1.0, "Cell_id": "A"}}
-    mock_resp = MagicMock(status_code=200, json=lambda: sample_state)
-    monkeypatch.setattr(nef_collector.requests, "get", lambda *a, **k: mock_resp)
+    mock_client = MagicMock(get_ue_movement_state=lambda: sample_state)
+    collector.client = mock_client
     monkeypatch.setattr(nef_collector.time, "sleep", lambda x: None)
     times = iter([0, 0.1, 1.1])
     monkeypatch.setattr(nef_collector.time, "time", lambda: next(times))

--- a/5g-network-optimization/services/nef-emulator/tests/test_integration.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_integration.py
@@ -2,8 +2,21 @@ import json
 from unittest.mock import MagicMock
 from pathlib import Path
 import importlib.util
+import sys
 
-COLLECTOR_PATH = Path(__file__).resolve().parents[2] / "ml-service" / "app" / "data" / "nef_collector.py"
+SERVICE_ROOT = Path(__file__).resolve().parents[2] / "ml-service"
+spec_app = importlib.util.spec_from_file_location(
+    "app", SERVICE_ROOT / "app" / "__init__.py", submodule_search_locations=[str(SERVICE_ROOT / "app")]
+)
+app_module = importlib.util.module_from_spec(spec_app)
+sys.modules["app"] = app_module
+sys.modules.setdefault(
+    "seaborn",
+    importlib.util.module_from_spec(importlib.util.spec_from_loader("seaborn", loader=None)),
+)
+spec_app.loader.exec_module(app_module)
+
+COLLECTOR_PATH = SERVICE_ROOT / "app" / "data" / "nef_collector.py"
 spec = importlib.util.spec_from_file_location("nef_collector", COLLECTOR_PATH)
 nef_collector = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(nef_collector)
@@ -11,20 +24,24 @@ NEFDataCollector = nef_collector.NEFDataCollector
 
 
 def test_login_success(monkeypatch):
+    mock_client = MagicMock()
+    mock_client.login.return_value = True
+    mock_client.token = "tok"
+    mock_client.get_headers.return_value = {"Authorization": "Bearer tok"}
+    monkeypatch.setattr(nef_collector, "NEFClient", lambda *a, **k: mock_client)
     collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
-    mock_resp = MagicMock(status_code=200, json=lambda: {"access_token": "tok"})
-    monkeypatch.setattr(nef_collector.requests, "post", lambda *a, **k: mock_resp)
     assert collector.login() is True
     assert collector.token == "tok"
     assert collector.headers["Authorization"] == "Bearer tok"
 
 
 def test_collect_training_data(monkeypatch, tmp_path):
+    sample_state = {"ue1": {"latitude": 0, "longitude": 0, "speed": 1.0, "Cell_id": "A"}}
+    mock_client = MagicMock()
+    mock_client.get_ue_movement_state.return_value = sample_state
+    monkeypatch.setattr(nef_collector, "NEFClient", lambda *a, **k: mock_client)
     collector = NEFDataCollector(nef_url="http://nef")
     collector.data_dir = str(tmp_path)
-    sample_state = {"ue1": {"latitude": 0, "longitude": 0, "speed": 1.0, "Cell_id": "A"}}
-    mock_resp = MagicMock(status_code=200, json=lambda: sample_state)
-    monkeypatch.setattr(nef_collector.requests, "get", lambda *a, **k: mock_resp)
     monkeypatch.setattr(nef_collector.time, "sleep", lambda x: None)
     times = iter([0, 0.1, 1.1])
     monkeypatch.setattr(nef_collector.time, "time", lambda: next(times))


### PR DESCRIPTION
## Summary
- centralize NEF emulator access in `NEFDataCollector` via `NEFClient`
- update unit tests to mock `NEFClient`

Refactor NEFDataCollector to delegate authentication and data retrieval to a new NEFClient, reducing duplicated HTTP logic and streamlining testability.

Enhancements:
- Centralize all NEF emulator HTTP interactions in NEFClient and remove direct requests usage from NEFDataCollector
- Refactor login and UE movement state retrieval methods to call NEFClient and expose its token and headers

Tests:
- Update unit and integration tests to mock NEFClient methods instead of patching HTTP requests
- Adjust dynamic import setup in tests to inject NEFClient and support mocking throughout test suites