### PR TITLE
Centralize logging configuration

### DIFF
--- a/5g-network-optimization/services/logging_config.py
+++ b/5g-network-optimization/services/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+
+
+def configure_logging(level=logging.INFO,
+                       fmt='%(asctime)s - %(name)s - %(levelname)s - %(message)s'):
+    """Configure application-wide logging.
+
+    This sets up the root logger only if no handlers are configured yet so
+    repeated calls have no side effects.
+    """
+    if not logging.getLogger().handlers:
+        logging.basicConfig(level=level, format=fmt)

--- a/5g-network-optimization/services/ml-service/app.py
+++ b/5g-network-optimization/services/ml-service/app.py
@@ -1,6 +1,12 @@
 """Main entry point for ML Service."""
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from logging_config import configure_logging
 from app import create_app
 
+configure_logging()
 app = create_app()
 
 if __name__ == "__main__":

--- a/5g-network-optimization/services/ml-service/app/__init__.py
+++ b/5g-network-optimization/services/ml-service/app/__init__.py
@@ -3,12 +3,6 @@ from flask import Flask
 import os
 import logging
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-
 def create_app(config=None):
     """Create and configure the Flask application."""
     app = Flask(__name__)

--- a/5g-network-optimization/services/ml-service/app/data/nef_collector.py
+++ b/5g-network-optimization/services/ml-service/app/data/nef_collector.py
@@ -22,11 +22,7 @@ class NEFDataCollector:
         self.data_dir = os.path.join(os.path.dirname(__file__), 'collected_data')
         os.makedirs(self.data_dir, exist_ok=True)
         
-        # Set up logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
+        # Set up logger for this collector
         self.logger = logging.getLogger('NEFDataCollector')
     
     def login(self):

--- a/5g-network-optimization/services/ml-service/collect_training_data.py
+++ b/5g-network-optimization/services/ml-service/collect_training_data.py
@@ -6,16 +6,18 @@ import json
 import time
 import logging
 from datetime import datetime
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from logging_config import configure_logging
 from app.data.nef_collector import NEFDataCollector
 
 logger = logging.getLogger(__name__)
 
 def main():
     """Main entry point for data collection script."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    )
+    configure_logging()
     parser = argparse.ArgumentParser(description='Collect training data from NEF emulator')
     parser.add_argument('--url', type=str, default='http://localhost:8080',
                         help='NEF emulator URL (default: http://localhost:8080)')

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/ue_movement.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/ue_movement.py
@@ -9,7 +9,6 @@ from app.tools import qos_callback
 from app.db.session import SessionLocal, client
 from app.api import deps
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 from app.schemas import Msg
 from app.tools import monitoring_callbacks, timer

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/utils.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/utils.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 import logging, requests, json
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/backend_pre_start.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/backend_pre_start.py
@@ -1,9 +1,12 @@
 import logging
+from pathlib import Path
+import sys
 from tenacity import after_log, before_log, retry, stop_after_attempt, wait_fixed
 from app.db.session import SessionLocal
 
 
-logging.basicConfig(level=logging.INFO)
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+from logging_config import configure_logging
 logger = logging.getLogger(__name__)
 
 max_tries = 60
@@ -35,4 +38,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    configure_logging()
     main()

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/celeryworker_pre_start.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/celeryworker_pre_start.py
@@ -1,10 +1,13 @@
 import logging
+from pathlib import Path
+import sys
 
 from tenacity import after_log, before_log, retry, stop_after_attempt, wait_fixed
 
 from app.db.session import SessionLocal
 
-logging.basicConfig(level=logging.INFO)
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+from logging_config import configure_logging
 logger = logging.getLogger(__name__)
 
 max_tries = 60 * 5  # 5 minutes
@@ -34,4 +37,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    configure_logging()
     main()

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/core/security.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/core/security.py
@@ -11,7 +11,6 @@ import logging
 # from fastapi.security.utils import get_authorization_scheme_param
 from app.core.config import settings
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/crud/crud_UE.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/crud/crud_UE.py
@@ -7,7 +7,6 @@ from app.crud.base import CRUDBase
 from app.models.UE import UE
 from app.schemas.UE import UECreate, UEUpdate
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/initial_data.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/initial_data.py
@@ -1,10 +1,14 @@
 import logging, json, os, requests
+from pathlib import Path
+import sys
 from evolved5g.sdk import CAPIFProviderConnector
 from app.db.init_db import init_db
 from app.db.session import SessionLocal
 from app.core.config import settings
 
-logging.basicConfig(level=logging.INFO)
+sys.path.append(str(Path(__file__).resolve().parents[4]))
+from logging_config import configure_logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,4 +129,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    configure_logging()
     main()

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/tests_pre_start.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/tests_pre_start.py
@@ -4,7 +4,6 @@ from tenacity import after_log, before_log, retry, stop_after_attempt, wait_fixe
 
 from app.db.session import SessionLocal
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 max_tries = 60 * 5  # 5 minutes

--- a/5g-network-optimization/services/nef-emulator/backend/app/app/tools/check_subscription.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/tools/check_subscription.py
@@ -1,8 +1,6 @@
 import logging
 import time
 from app.crud import crud_mongo
-
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def check_expiration_time(expire_time):


### PR DESCRIPTION
## Summary
- add `logging_config.py` utility
- remove direct `logging.basicConfig` calls
- call `configure_logging()` from service entrypoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631c76ffd883339f833bc759be9280

## Summary by Sourcery

Centralize application-wide logging by introducing a dedicated logging_config module and replacing ad-hoc basicConfig calls with a unified configure_logging() invocation across services.

Enhancements:
- Add logging_config.configure_logging() utility to encapsulate root logger setup.
- Remove scattered logging.basicConfig calls from ML service and NEF emulator modules.
- Invoke configure_logging() in service entrypoints and module initializers for consistent logging initialization.