### PR TITLE
Centralize default test features

### DIFF
--- a/5g-network-optimization/services/ml-service/app/api/visualization.py
+++ b/5g-network-optimization/services/ml-service/app/api/visualization.py
@@ -3,7 +3,7 @@ from flask import Blueprint, jsonify, request, current_app, send_file
 import os
 import json
 import logging
-from app.models.antenna_selector import AntennaSelector
+from app.models.antenna_selector import AntennaSelector, DEFAULT_TEST_FEATURES
 from app.visualization.plotter import plot_antenna_coverage, plot_movement_trajectory
 from app.utils.synthetic_data import generate_synthetic_training_data
 
@@ -22,16 +22,7 @@ def coverage_map():
         # First, check if the model is trained
         try:
             # Try a simple prediction to see if model is trained
-            test_features = {
-                'latitude': 500, 
-                'longitude': 500, 
-                'speed': 1.0,
-                'direction_x': 0.7,
-                'direction_y': 0.7,
-                'rsrp_current': -90,
-                'sinr_current': 10
-            }
-            model.predict(test_features)
+            model.predict(DEFAULT_TEST_FEATURES)
         except Exception as e:
             # Model is not trained, train it with synthetic data
             logger.warning(

--- a/5g-network-optimization/services/ml-service/app/initialization/model_init.py
+++ b/5g-network-optimization/services/ml-service/app/initialization/model_init.py
@@ -1,7 +1,7 @@
 """Model initialization utilities."""
 import os
 import logging
-from app.models.antenna_selector import AntennaSelector
+from app.models.antenna_selector import AntennaSelector, DEFAULT_TEST_FEATURES
 
 from app.utils.synthetic_data import generate_synthetic_training_data
 
@@ -16,16 +16,7 @@ def initialize_model(model_path=None):
     
     # Try a simple prediction to check if the model is trained
     try:
-        test_features = {
-            'latitude': 500,
-            'longitude': 500,
-            'speed': 1.0,
-            'direction_x': 0.7,
-            'direction_y': 0.7,
-            'rsrp_current': -90,
-            'sinr_current': 10
-        }
-        model.predict(test_features)
+        model.predict(DEFAULT_TEST_FEATURES)
         logger.info("Model is already trained and ready")
         return model
     except Exception as e:

--- a/5g-network-optimization/services/ml-service/app/models/antenna_selector.py
+++ b/5g-network-optimization/services/ml-service/app/models/antenna_selector.py
@@ -6,6 +6,16 @@ import joblib
 import os
 import logging
 
+DEFAULT_TEST_FEATURES = {
+    "latitude": 500,
+    "longitude": 500,
+    "speed": 1.0,
+    "direction_x": 0.7,
+    "direction_y": 0.7,
+    "rsrp_current": -90,
+    "sinr_current": 10,
+}
+
 class AntennaSelector:
     """ML model for selecting optimal antenna based on UE data."""
     

--- a/5g-network-optimization/services/ml-service/app/visualization/plotter.py
+++ b/5g-network-optimization/services/ml-service/app/visualization/plotter.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn as sns
+from app.models.antenna_selector import DEFAULT_TEST_FEATURES
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -40,16 +41,7 @@ def plot_antenna_coverage(model, output_dir='output'):
     
     # First check if model is trained by making a test prediction
     try:
-        test_features = {
-            'latitude': 500, 
-            'longitude': 500, 
-            'speed': 1.0,
-            'direction_x': 0.7,
-            'direction_y': 0.7,
-            'rsrp_current': -90,
-            'sinr_current': 10
-        }
-        model.predict(test_features)
+        model.predict(DEFAULT_TEST_FEATURES)
         model_trained = True
     except Exception as e:
         logger.warning(f"Model not properly trained: {e}")


### PR DESCRIPTION
## Summary
- define `DEFAULT_TEST_FEATURES` in `antenna_selector`
- reuse the constant in visualization, API endpoint, and model initialization
- remove duplicated inline dictionaries

Centralize the default test features into a shared constant and replace duplicated inline test feature definitions with this constant across the codebase

New Features:
- Introduce DEFAULT_TEST_FEATURES constant in the antenna_selector model

Enhancements:
- Replace inline test feature dictionaries in plotter with DEFAULT_TEST_FEATURES
- Use DEFAULT_TEST_FEATURES in the API visualization endpoint instead of duplicate dict
- Reuse DEFAULT_TEST_FEATURES in model initialization instead of inline definitions