### PR TITLE
Ensure consistent matplotlib backend during tests

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/conftest.py
+++ b/5g-network-optimization/services/ml-service/tests/conftest.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import importlib.util
 import sys
 import pytest
+import matplotlib
+
+matplotlib.use("Agg")
 
 # Ensure the service package can be imported as ``app`` before test collection.
 SERVICE_ROOT = Path(__file__).resolve().parents[1]

--- a/5g-network-optimization/services/ml-service/tests/test_plotter.py
+++ b/5g-network-optimization/services/ml-service/tests/test_plotter.py
@@ -1,7 +1,5 @@
 import importlib.util
 from pathlib import Path
-import matplotlib
-matplotlib.use("Agg")
 
 # Load plotter module directly to avoid package import issues
 PLOTTER_PATH = Path(__file__).resolve().parents[1] / "app" / "visualization" / "plotter.py"


### PR DESCRIPTION
## Summary
- configure the Agg backend in `tests/conftest.py`
- remove redundant backend initialization from `test_plotter.py`

Configure the matplotlib Agg backend globally for tests and remove redundant backend setup from individual test files

Tests:
- Set matplotlib backend to Agg in conftest.py for consistent test plotting
- Remove redundant matplotlib backend initialization from test_plotter.py