### PR TITLE
Delegate NEFDataCollector login to client

### DIFF
--- a/5g-network-optimization/services/ml-service/app/data/nef_collector.py
+++ b/5g-network-optimization/services/ml-service/app/data/nef_collector.py
@@ -17,8 +17,6 @@ class NEFDataCollector:
         self.nef_url = nef_url
         self.username = username
         self.password = password
-        self.token = None
-        self.headers = {}
         self.data_dir = os.path.join(os.path.dirname(__file__), 'collected_data')
         os.makedirs(self.data_dir, exist_ok=True)
         
@@ -26,15 +24,8 @@ class NEFDataCollector:
         self.logger = logging.getLogger('NEFDataCollector')
     
     def login(self):
-        """Login to NEF emulator and store access token."""
-        success = self.client.login()
-        if success:
-            self.token = self.client.token
-            self.headers = self.client.get_headers()
-        else:
-            self.token = None
-            self.headers = {}
-        return success
+        """Authenticate with the NEF emulator via the underlying client."""
+        return self.client.login()
     
     def get_ue_movement_state(self):
         """Get current state of all UEs in movement."""

--- a/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
+++ b/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
@@ -30,7 +30,7 @@ def test_login_success():
     with patch.object(nef_collector, "NEFClient", lambda *a, **k: mock_client):
         collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
         assert collector.login() is True
-        assert collector.token == "tok"
+        assert collector.client.token == "tok"
         mock_client.login.assert_called_once()
 
 

--- a/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
+++ b/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
@@ -31,8 +31,8 @@ def test_login(monkeypatch):
     monkeypatch.setattr(nef_collector, "NEFClient", lambda *a, **k: mock_client)
     collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
     assert collector.login() is True
-    assert collector.token == "tok"
-    assert collector.headers["Authorization"] == "Bearer tok"
+    assert collector.client.token == "tok"
+    assert collector.client.get_headers()["Authorization"] == "Bearer tok"
 
 
 def test_get_ue_movement_state(monkeypatch):

--- a/5g-network-optimization/services/nef-emulator/tests/test_integration.py
+++ b/5g-network-optimization/services/nef-emulator/tests/test_integration.py
@@ -31,8 +31,8 @@ def test_login_success(monkeypatch):
     monkeypatch.setattr(nef_collector, "NEFClient", lambda *a, **k: mock_client)
     collector = NEFDataCollector(nef_url="http://nef", username="u", password="p")
     assert collector.login() is True
-    assert collector.token == "tok"
-    assert collector.headers["Authorization"] == "Bearer tok"
+    assert collector.client.token == "tok"
+    assert collector.client.get_headers()["Authorization"] == "Bearer tok"
 
 
 def test_collect_training_data(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- simplify `NEFDataCollector.login` to rely on `NEFClient`
- access client token/headers directly in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686322df1f2c8333a19d5e89a9fad515