### PR TITLE
Add reusable test module loader

### DIFF
--- a/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
+++ b/5g-network-optimization/services/ml-service/tests/integration/test_nef_integration.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 import importlib.util
 from pathlib import Path
+
+from test_helpers import load_module
 import sys
 
 SERVICE_ROOT = Path(__file__).resolve().parents[2]
@@ -16,9 +18,7 @@ sys.modules.setdefault(
 spec_app.loader.exec_module(app_module)
 
 NEF_COLLECTOR_PATH = SERVICE_ROOT / "app" / "data" / "nef_collector.py"
-spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
-nef_collector = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nef_collector)
+nef_collector = load_module(NEF_COLLECTOR_PATH, "nef_collector")
 NEFDataCollector = nef_collector.NEFDataCollector
 
 

--- a/5g-network-optimization/services/ml-service/tests/test_antenna_selector.py
+++ b/5g-network-optimization/services/ml-service/tests/test_antenna_selector.py
@@ -1,12 +1,11 @@
 import numpy as np
 
-import importlib.util
 from pathlib import Path as PathlibPath
 
+from test_helpers import load_module
+
 ANT_PATH = PathlibPath(__file__).resolve().parents[1] / "app" / "models" / "antenna_selector.py"
-spec = importlib.util.spec_from_file_location("antenna_selector", ANT_PATH)
-antenna_selector = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(antenna_selector)
+antenna_selector = load_module(ANT_PATH, "antenna_selector")
 AntennaSelector = antenna_selector.AntennaSelector
 
 

--- a/5g-network-optimization/services/ml-service/tests/test_helpers.py
+++ b/5g-network-optimization/services/ml-service/tests/test_helpers.py
@@ -1,0 +1,26 @@
+"""Utilities for ml-service tests."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from types import ModuleType
+from pathlib import Path
+
+
+def load_module(path: Path, name: str) -> ModuleType:
+    """Load a Python module from ``path`` with the given ``name``.
+
+    Parameters
+    ----------
+    path: Path
+        Filesystem path to the module to load.
+    name: str
+        Module name under which it will be loaded.
+
+    Returns
+    -------
+    ModuleType
+        The loaded module object.
+    """
+    spec = spec_from_file_location(name, path)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/5g-network-optimization/services/ml-service/tests/test_ml_components.py
+++ b/5g-network-optimization/services/ml-service/tests/test_ml_components.py
@@ -3,17 +3,16 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.model_selection import train_test_split
-import importlib.util
 from pathlib import Path
+
+from test_helpers import load_module
 import os
 import logging
 
 logger = logging.getLogger(__name__)
 
 ANT_PATH = Path(__file__).resolve().parents[1] / "app" / "models" / "antenna_selector.py"
-spec = importlib.util.spec_from_file_location("antenna_selector", ANT_PATH)
-antenna_selector = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(antenna_selector)
+antenna_selector = load_module(ANT_PATH, "antenna_selector")
 AntennaSelector = antenna_selector.AntennaSelector
 
 def generate_synthetic_data(num_samples=500):

--- a/5g-network-optimization/services/ml-service/tests/test_model.py
+++ b/5g-network-optimization/services/ml-service/tests/test_model.py
@@ -3,14 +3,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 import os
 from sklearn.model_selection import train_test_split
-
-import importlib.util
 from pathlib import Path
 
+from test_helpers import load_module
+
 ANT_PATH = Path(__file__).resolve().parents[1] / "app" / "models" / "antenna_selector.py"
-spec = importlib.util.spec_from_file_location("antenna_selector", ANT_PATH)
-antenna_selector = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(antenna_selector)
+antenna_selector = load_module(ANT_PATH, "antenna_selector")
 AntennaSelector = antenna_selector.AntennaSelector
 
 def generate_synthetic_data(num_samples=500):

--- a/5g-network-optimization/services/ml-service/tests/test_nef_client.py
+++ b/5g-network-optimization/services/ml-service/tests/test_nef_client.py
@@ -1,10 +1,9 @@
-import importlib.util
 from pathlib import Path
 
+from test_helpers import load_module
+
 NEF_CLIENT_PATH = Path(__file__).resolve().parents[1] / "app" / "clients" / "nef_client.py"
-spec = importlib.util.spec_from_file_location("nef_client", NEF_CLIENT_PATH)
-nef_client = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nef_client)
+nef_client = load_module(NEF_CLIENT_PATH, "nef_client")
 NEFClient = nef_client.NEFClient
 
 

--- a/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
+++ b/5g-network-optimization/services/ml-service/tests/test_nef_collector.py
@@ -4,6 +4,8 @@ import json
 from unittest.mock import MagicMock
 import sys
 
+from test_helpers import load_module
+
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 spec_app = importlib.util.spec_from_file_location(
     "app", SERVICE_ROOT / "app" / "__init__.py", submodule_search_locations=[str(SERVICE_ROOT / "app")]
@@ -17,9 +19,7 @@ sys.modules.setdefault(
 spec_app.loader.exec_module(app_module)
 
 NEF_COLLECTOR_PATH = SERVICE_ROOT / "app" / "data" / "nef_collector.py"
-spec = importlib.util.spec_from_file_location("nef_collector", NEF_COLLECTOR_PATH)
-nef_collector = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nef_collector)
+nef_collector = load_module(NEF_COLLECTOR_PATH, "nef_collector")
 NEFDataCollector = nef_collector.NEFDataCollector
 
 

--- a/5g-network-optimization/services/ml-service/tests/test_plotter.py
+++ b/5g-network-optimization/services/ml-service/tests/test_plotter.py
@@ -1,11 +1,10 @@
-import importlib.util
 from pathlib import Path
+
+from test_helpers import load_module
 
 # Load plotter module directly to avoid package import issues
 PLOTTER_PATH = Path(__file__).resolve().parents[1] / "app" / "visualization" / "plotter.py"
-spec = importlib.util.spec_from_file_location("plotter", PLOTTER_PATH)
-plotter = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(plotter)
+plotter = load_module(PLOTTER_PATH, "plotter")
 plot_antenna_coverage = plotter.plot_antenna_coverage
 plot_movement_trajectory = plotter.plot_movement_trajectory
 


### PR DESCRIPTION
## Summary
- add `load_module` helper in ml-service tests
- refactor tests to use the helper and reduce import boilerplate

## Testing
- `pytest 5g-network-optimization/services/ml-service/tests/test_nef_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68632fb451188333a0b84f8e90aeb1f3

## Summary by Sourcery

Add a test_helpers.load_module utility and update existing tests to use it for module loading, reducing boilerplate.

New Features:
- Add a reusable load_module helper in test_helpers for dynamic module loading

Enhancements:
- Refactor tests across the suite to replace manual importlib loading with the new load_module helper