### PR TITLE
Improve unused-code workflow

### DIFF
--- a/.github/workflows/unused-code.yml
+++ b/.github/workflows/unused-code.yml
@@ -20,9 +20,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
 
       - name: Install vulture
         run: pip install vulture


### PR DESCRIPTION
## Summary
- add caching in GitHub Actions to speed up installing `vulture`

CI:
- Cache pip cache directory keyed by OS, Python version, and requirements.txt hash