### PR TITLE
Fix unused import

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/UE.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/UE.py
@@ -2,7 +2,6 @@ from typing import Any, List
 from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from sqlalchemy import null
 from sqlalchemy.orm import Session
 
 from app import crud, models, schemas


### PR DESCRIPTION
## Summary
- remove unused `sqlalchemy.null` import in UE API endpoint

Enhancements:
- Remove the unused import of sqlalchemy.null in app/api/api_v1/endpoints/UE.py.