### PR TITLE
Remove unused Event import

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/schemas/qosMonitoring.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/schemas/qosMonitoring.py
@@ -1,4 +1,3 @@
-from threading import Event
 from typing import List, Optional
 from pydantic import BaseModel, Field, IPvAnyAddress, AnyHttpUrl, constr
 from enum import Enum


### PR DESCRIPTION
## Summary
- clean up `qosMonitoring.py` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ml_service')*

------
https://chatgpt.com/codex/tasks/task_e_6863d2b163e4833399ad6e40ce380a97