### PR TITLE
Update README instructions for presentation assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,19 @@ subfolders of `output/`:
 - `output/coverage/` – antenna coverage maps
 - `output/trajectory/` – UE movement trajectories
 - `output/mobility/` – mobility model examples from the NEF emulator tests
+- `presentation_assets/` – pre-rendered graphs and captions for reports
 
 These folders are created automatically when the plots are produced.
+
+Run the helper scripts below to create the presentation assets and a PDF
+overview:
+
+```bash
+python scripts/generate_presentation_assets.py
+python scripts/build_presentation_pdf.py
+```
+The second command collects the generated images and captions under
+`presentation_assets/` and writes `overview.pdf`.
 
 ## Useful Scripts
 


### PR DESCRIPTION
## Summary
- mention `presentation_assets` directory
- document running `generate_presentation_assets.py` and `build_presentation_pdf.py`

Update README to document the new presentation_assets directory and provide instructions to generate presentation assets and build an overview PDF

Documentation:
- Add `presentation_assets/` directory description for pre-rendered graphs and captions
- Document usage of `scripts/generate_presentation_assets.py` and `scripts/build_presentation_pdf.py` commands to create and compile presentation assets into a PDF