### PR TITLE
Fix endpoint imports

### DIFF
--- a/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/__init__.py
+++ b/5g-network-optimization/services/nef-emulator/backend/app/app/api/api_v1/endpoints/__init__.py
@@ -1,11 +1,29 @@
-from .login import router
-from .users import router
-from .utils import router
-from .ue_movement import router
-from .paths import router
-from .gNB import router
-from .Cell import router
-from .UE import router
-from .qosInformation import router
-from .qosMonitoring import router
-from .monitoringevent import router
+"""Expose API endpoint modules."""
+
+from . import (
+    login,
+    users,
+    utils,
+    ue_movement,
+    paths,
+    gNB,
+    Cell,
+    UE,
+    qosInformation,
+    qosMonitoring,
+    monitoringevent,
+)
+
+__all__ = [
+    "login",
+    "users",
+    "utils",
+    "ue_movement",
+    "paths",
+    "gNB",
+    "Cell",
+    "UE",
+    "qosInformation",
+    "qosMonitoring",
+    "monitoringevent",
+]


### PR DESCRIPTION
## Summary
- expose endpoint modules through `endpoints/__init__.py`
- define `__all__` for explicit exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686437dab5c8833394bc13bff2a602e2